### PR TITLE
Infra Update: `spack.yaml` Simplification, new Projections

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -18,40 +18,26 @@ spack:
     # Specifications that apply to all packages
     all:
       # TODO: Specify compiler/targets for all packages
-      # compiler: [intel@19.0.5.281]
-      # target: [x86_64]
+      # require:
+      #   - '%intel@19.0.5.281'
+      #   - 'target=x86_64'
   view: true
   concretizer:
     unify: true
   modules:
     default:
-      enable:
-        - tcl
-      roots:
-        tcl: $spack/../release/modules
-        lmod: $spack/../release/lmod
       tcl:
-        hash_length: 0
         include:
           # Explicitly, which packages are accessible as modules
           # TODO: Add packages that will be included as modules
           # - MODEL
-        exclude_implicits: true
-        all:
-          autoload: direct
-          conflict:
-            - '{name}'
-          environment:
-            set:
-              'SPACK_{name}_ROOT': '{prefix}'
         projections:
           # TODO: Add explicit projections for modules that will be found with `module load`.
           # Naming scheme for the above included modules.
           # These projection versions must be the same as the
           # `spack.packages.*.require[0]` version but without the `@git.`.
           # Ex. `require` version `@git.2024.04.21` -> projection `2024.04.21`.
-          all: '{name}/{version}'
-          # MODEL: '{name}/VERSION'
+          # MODEL: '{name}/VERSION-{hash:7}'
   # config:
   #   overridden spack configurations, if needed
   # mirrors:

--- a/spack.yaml
+++ b/spack.yaml
@@ -37,7 +37,8 @@ spack:
           # These projection versions must be the same as the
           # `spack.packages.*.require[0]` version but without the `@git.`.
           # Ex. `require` version `@git.2024.04.21` -> projection `2024.04.21`.
-          # MODEL: '{name}/VERSION-{hash:7}'
+          # MODEL: '{name}/VERSION'
+          # COMPONENT: '{name}/VERSION-{hash:7}'
   # config:
   #   overridden spack configurations, if needed
   # mirrors:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,16 +4,18 @@
 # configuration settings.
 spack:
   specs:
+    # The root Spack Bundle Recipe (SBR) for the model and overall version of
+    # the deployment:
     # TODO: Replace the MODEL and VERSION.
-    # The root SBD for the model and overall version of the deployment:
     # - MODEL@git.VERSION
+
   packages:
-    # TODO: Specify versions and variants of dependencies where required
-    # Specification of dependency versions and variants goes here.
-    # CI/CD requires that the first element of the require is only a version:
+    # Specification of dependency versions and variants. CI/CD requires that
+    # the first element of the require is only a version:
+    # TODO: Specify versions and variants of dependencies as required.
     # openmpi:
     #   require:
-    #     - '@4.0.2'
+    #     - '@4.1.5'
 
     # Specifications that apply to all packages
     all:
@@ -28,17 +30,24 @@ spack:
     default:
       tcl:
         include:
-          # TODO: Add packages that will be included as modules
-          # - PACKAGE
+          # TODO: Add MODEL and PACKAGEs that will have a corresponding module
+          # - MODEL
+          # - PACKAGE1
+          # - PACKAGE2
         projections:
-          # TODO: Add explicit projections for modules that will be found
-          # with `module load`.
-          # Naming scheme for the above included modules.
-          # These projection versions must be the same as the
-          # `spack.packages.*.require[0]` version but without the `@git.`.
-          # Ex. `require` version `@git.2024.04.21` -> projection `2024.04.21`.
+          # These projection VERSIONs must be the same as the
+          # `spack.packages.*.require[0]` VERSION but without the `@git.` and
+          # without the RHS of the equals sign, if there is one.
+          #
+          # For a MODEL, an example projection is `{name}/2024.10.0`.
+          # For a PACKAGE where `require` VERSION is
+          # `@git.2024.04.21=access-esm1.5`, the projection becomes
+          # `{name}/2024.04.21-{hash:7}`.
+          # TODO: Add explicit projections for modules that will be found with
+          #       `module load`.
           # MODEL: '{name}/VERSION'
-          # COMPONENT: '{name}/VERSION-{hash:7}'
+          # PACKAGE1: '{name}/VERSION1-{hash:7}'
+          # PACKAGE2: '{name}/VERSION2-{hash:7}'
   # config:
   #   overridden spack configurations, if needed
   # mirrors:

--- a/spack.yaml
+++ b/spack.yaml
@@ -28,11 +28,11 @@ spack:
     default:
       tcl:
         include:
-          # Explicitly, which packages are accessible as modules
           # TODO: Add packages that will be included as modules
-          # - MODEL
+          # - PACKAGE
         projections:
-          # TODO: Add explicit projections for modules that will be found with `module load`.
+          # TODO: Add explicit projections for modules that will be found
+          # with `module load`.
           # Naming scheme for the above included modules.
           # These projection versions must be the same as the
           # `spack.packages.*.require[0]` version but without the `@git.`.


### PR DESCRIPTION
> [!NOTE]
> This is an infrastructure update, NOT a proper model update. No release will be created when merging this PR. 

In this PR:
* Update compiler requirement to be strict rather than a preference (in `spack.packages.all`)
* Simplify `spack.modules` section to not include parts already inherited from `spack-config`
* Update `spack.modules.default.tcl.projections` to have the `-{hash:7}` appended

Closes #6
