### PR TITLE
Update spack.yaml with Dave Bi and Pearse Buchanan's changes for ESM 1.6 MOTHBALLED!! BAD

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.fed85faf4690642fc61a0e1f1d54da23105f6acf=access-esm1.5'
     um7:
       require:
         - '@git.18-esm15-cable3=access-esm1.5'
@@ -45,7 +45,7 @@ spack:
         - '@git.dev_2024.11.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.11.0'
+        - '@git.9b79d47d5b803e0cc832bb491f38020e8fcee6e5'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -68,7 +68,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2024.10.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/fed85faf4690642fc61a0e1f1d54da23105f6acf-{hash:7}'
           um7: '{name}/18-esm15-cable3-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p6@git.2024.10.0
+    - access-esm1p6@git.2024.12.0
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -67,7 +67,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2024.10.0'
+          access-esm1p6: '{name}/2024.12.0'
           cice4: '{name}/fed85faf4690642fc61a0e1f1d54da23105f6acf-{hash:7}'
           um7: '{name}/18-esm15-cable3-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'


### PR DESCRIPTION
Updates include:
Dave Bi cice update
Pearse Buchanan Wombat-lite

Still to come: Dave Bi's MOM5 updates and eventually using CICE5

---
:rocket: The latest prerelease `access-esm1p6/pr19-3` at 87713ec0b25a527f77c7338b8481b28915445449 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/19#issuecomment-2533706744 :rocket:

