### PR TITLE
Second try at ESM1.6 pre-alpha build with latest CABLE, Dave Bi and Pearse Buchanan's changes

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,11 +17,11 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.dev_2024.08.14=access-esm1.6'
+        - '@git.update_DaveBi=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.wombatlite-sinking'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -73,9 +73,9 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/dev_2024.08.14-{hash:7}'
+          mom5: '{name}/update_DaveBi-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr23-1` at a11279b30bc120be76fbe1512b37319e83b56619 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/23#issuecomment-2540308108 :rocket:
