### PR TITLE
Build ESM1.6 with wombatlite-sinking

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2024.12.0
+    - access-esm1p6@git.dev_2024.12.1
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -48,6 +48,7 @@ spack:
     access-fms:
       require:
         - '@git.dev_2024.12.0'
+    # Includes wombatlite-sinking
     access-generic-tracers:
       require:
         - '@git.dev_2024.12.0'
@@ -72,7 +73,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2024.12.0'
+          access-esm1p6: '{name}/dev_2024.12.1'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2024.12.2
+    - access-esm1p6@git.dev_2025.01.0
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -48,10 +48,10 @@ spack:
     access-fms:
       require:
         - '@git.dev_2024.12.0'
-    # Includes wombatlite-sinking: https://github.com/ACCESS-NRI/GFDL-generic-tracers/commit/991e993e8391470711a12bcc66480925cb506d30
+    # Includes wombatlite-sinking: https://github.com/ACCESS-NRI/GFDL-generic-tracers/commit/4779c63d8b61c191152823404015bdfe963ff92a
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.2'
+        - '@git.dev_2025.01.0'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -73,7 +73,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2024.12.2'
+          access-esm1p6: '{name}/dev_2025.01.0'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -47,7 +47,7 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2025.02.2'
     # Includes wombatlite-sinking: https://github.com/ACCESS-NRI/GFDL-generic-tracers/commit/4779c63d8b61c191152823404015bdfe963ff92a
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,7 +21,7 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'
@@ -47,11 +47,11 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.dev_2025.02.2'
+        - '@git.mom5-dev-2025.02.3'
     # Includes wombatlite-sinking: https://github.com/ACCESS-NRI/GFDL-generic-tracers/commit/4779c63d8b61c191152823404015bdfe963ff92a
     access-generic-tracers:
       require:
-        - '@git.dev_2025.01.0'
+        - '@git.dev-2025.02.1'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -74,7 +74,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.01.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/access-esm1.5-2025.03.001-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2024.12.1
+    - access-esm1p6@git.dev_2024.12.2
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -48,10 +48,10 @@ spack:
     access-fms:
       require:
         - '@git.dev_2024.12.0'
-    # Includes wombatlite-sinking
+    # Includes wombatlite-sinking: https://github.com/ACCESS-NRI/GFDL-generic-tracers/commit/991e993e8391470711a12bcc66480925cb506d30
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -73,7 +73,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2024.12.1'
+          access-esm1p6: '{name}/dev_2024.12.2'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr26-14` at b8dbd170330320ef3a04e2d48dd63be5a60e4b11 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/26#issuecomment-2699574748 :rocket:









