### PR TITLE
Spin up b

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e=access-esm1.6'
+        - '@git.ef7bce300a148e52b52cc16e5eece8299b1cc0dc=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e-{hash:7}'
+          um7: '{name}/ef7bce300a148e52b52cc16e5eece8299b1cc0dc-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # cc732bb 
     um7:
       require:
-        - '@git.snminBug=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
+        - '@git.75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
+          um7: '{name}/75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,10 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # cc732bb 
+    # 
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.snminBug=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/snminBug-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.ef7bce300a148e52b52cc16e5eece8299b1cc0dc=access-esm1.6'
+        - '@git.fec66db8f63d9a784ec435703a63983d6d2119ee=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/ef7bce300a148e52b52cc16e5eece8299b1cc0dc-{hash:7}'
+          um7: '{name}/-fec66db8f63d9a784ec435703a63983d6d2119ee{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,8 +25,7 @@ spack:
     # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
     um7:
       require:
-        - '@git.snminBug=access-esm1.6'
-        # - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,8 +75,8 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-{hash:7}'
-          #um7: '{name}/dev-access-esm1.6-{hash:7}'
+          #um7: '{name}/snminBug-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 
+    # snmin=1.0 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
+        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7-debug=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/22-land-parameters-in-code-{hash:7}'
+          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
+    # 1cd51aa - read params from nml files 
     um7:
       require:
         - '@git.add-user-switches_draft2=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # snmin=0.1 
+    # USE snmin directly from runtime_opts mod
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,6 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
+    # Root fractions revised by rml
     um7:
       require:
         - '@git.RevisedRootFractions=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # read params from nml files fix bug # 9ad2fc0..ecc3524
+    # read params from nml files fix bug # 5da9977 
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/-fec66db8f63d9a784ec435703a63983d6d2119ee{hash:7}'
+          um7: '{name}/fec66db8f63d9a784ec435703a63983d6d2119ee-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,11 +22,12 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # read params from nml files fix bug # 5da9977 
+    
+    # branch = 22-land-parameters-in-code
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.22-land-parameters-in-code=access-esm1.6'
+        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.250895beda758da411ac4431174d59db1f2231df=access-esm1.6'
+        - '@git.4b6fc567235eacb8e8978b7f41d2607faeca0e1f=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/250895beda758da411ac4431174d59db1f2231df-{hash:7}'
+          um7: '{name}/4b6fc567235eacb8e8978b7f41d2607faeca0e1f-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # snmin=0.1 
     um7:
       require:
-        - '@git.snminBug=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.fec66db8f63d9a784ec435703a63983d6d2119ee=access-esm1.6'
+        - '@git.4fa79c73652f19f7e89ceba0890571187b86f989=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/fec66db8f63d9a784ec435703a63983d6d2119ee-{hash:7}'
+          um7: '{name}/4fa79c73652f19f7e89ceba0890571187b86f989-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.4b6fc567235eacb8e8978b7f41d2607faeca0e1f=access-esm1.6'
+        - '@git.4c20c873cc26b447a2df4520d81e1b67dcfcb8a8=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     um7:
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.test_2da305=access-esm1.6'
+        - '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/test_2da305-{hash:7}'
+          um7: '{name}/22-land-parameters-in-code-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -76,6 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
+          um7: '{name}/snminBug-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.4fa79c73652f19f7e89ceba0890571187b86f989=access-esm1.6'
+        - '@git.250895beda758da411ac4431174d59db1f2231df=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/4fa79c73652f19f7e89ceba0890571187b86f989-{hash:7}'
+          um7: '{name}/250895beda758da411ac4431174d59db1f2231df-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,8 +25,8 @@ spack:
     # 1cd51aa - read params from nml files redux 
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
-        #- '@git.22-land-parameters-in-code=access-esm1.6'
+        #- '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/22-land-parameters-in-code-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod
+    # USE snmin directly from runtime_opts mod && snmin = 1.0
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,10 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # Root fractions revised by rml
+    # 2da3053c674c44cc683bcc4837846d7b44a4cd30
     um7:
       require:
-        - '@git.RevisedRootFractions=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/RevisedRootFractions-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/RevisePastWeek-{hash:7}'
+          um7: '{name}/RevisedRootFractions-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.RevisePastWeek=access-esm1.6'
+        - '@git.RevisedRootFractions=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     um7:
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.22-land-parameters-in-code=access-esm1.6'
+        - '@git.test_2da305=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/22-land-parameters-in-code-{hash:7}'
+          um7: '{name}/test_2da305-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,8 +22,8 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # read params from nml files fix bug 
-    um7:
+    # read params from nml files fix bug # 9ad2fc0..ecc3524
+    um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
         - '@git.22-land-parameters-in-code=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/snminBug-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          #um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # snmin=1.0 
+    # snmin=0.1 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,8 @@ spack:
     # 1cd51aa - read params from nml files redux 
     um7:
       require:
-        - '@git.22-land-parameters-in-code=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
+        #- '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/22-land-parameters-in-code-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/4b6fc567235eacb8e8978b7f41d2607faeca0e1f-{hash:7}'
+          um7: '{name}/4c20c873cc26b447a2df4520d81e1b67dcfcb8a8-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # 2da3053c674c44cc683bcc4837846d7b44a4cd30
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.snminBug=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/snminBug-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 1.0
+    # USE snmin directly from runtime_opts mod && snmin = 0.1
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # be2f3cb 
+    # cc732bb 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.update_DaveBi=access-esm1.6'
+        - '@git.dev_2024.08.14=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.wombatlite-sinking'
+        - '@git.dev_2024.12.0'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -75,7 +75,7 @@ spack:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/update_DaveBi-{hash:7}'
+          mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.add-user-switches_draft2=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,8 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          #um7: '{name}/snminBug-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/add-user-switches_draft2-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 1cd51aa - read params from nml files 
+    # 1cd51aa - read params from nml files redux 
     um7:
       require:
         - '@git.22-land-parameters-in-code=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 1cd51aa - read params from nml files redux 
+    # read params from nml files fix bug 
     um7:
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # 1cd51aa - read params from nml files 
     um7:
       require:
-        - '@git.add-user-switches_draft2=access-esm1.6'
+        - '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/add-user-switches_draft2-{hash:7}'
+          um7: '{name}/22-land-parameters-in-code-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,8 @@ spack:
     # USE snmin directly from runtime_opts mod && snmin = 0.1
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.snminBug=access-esm1.6'
+        # - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-access-esm1.6-{hash:7}'
+          um7: '{name}/snminBug-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.RevisePastWeek-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,11 +17,11 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.dev_2024.08.14=access-esm1.6'
+        - '@git.update_DaveBi=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.wombatlite-sinking'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -73,9 +73,9 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/dev_2024.08.14-{hash:7}'
+          mom5: '{name}/update_DaveBi-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.RevisePastWeek-access-esm1.6=access-esm1.6'
+        - '@git.RevisePastWeek=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/RevisePastWeek-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 1.0 5f4df5d93f1d3f702a4cfe69290cf6a87996cc61
+    # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
+          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-debug-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 2da3053c674c44cc683bcc4837846d7b44a4cd30
+    # be2f3cb 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7-debug=access-esm1.6'
+        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-debug-{hash:7}'
+          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 0.1
+    # USE snmin directly from runtime_opts mod && snmin = 1.0 5f4df5d93f1d3f702a4cfe69290cf6a87996cc61
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'


### PR DESCRIPTION
Include my branch including CABLE updates intended for spin up run 

---
:rocket: The latest prerelease `access-esm1p6/pr28-46` at 0934cc27adc29a4f70f73ab86801130ec3bd7f36 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/28#issuecomment-2661092025 :rocket:








































