### PR TITLE
Include WOMBAT-lite tracer sinking bug fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -13,11 +13,11 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.dev_2024.08.14=access-esm1.6'
+        - '@git.update_DaveBi=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.wombatlite-sinking'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -67,9 +67,9 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/dev_2024.08.14-{hash:7}'
+          mom5: '{name}/update_DaveBi-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2025.01.1'
+        - '@git.dev_2025.01.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.update_DaveBi=access-esm1.6'
+        - '@git.dev_2024.08.14=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.wombatlite-sinking'
+        - '@git.dev_2024.12.0'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -69,7 +69,7 @@ spack:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/update_DaveBi-{hash:7}'
+          mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.2'
+        - '@git.dev_2025.01.0'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2025.01.0'
+        - '@git.dev_2025.01.1'
     access-mocsy:
       require:
         - '@git.2017.12.0'


### PR DESCRIPTION
Version [dev_2025.01.0]( https://github.com/ACCESS-NRI/GFDL-generic-tracers/releases/tag/dev_2025.01.0) of access-generic-tracers includes an important bug fix in WOMBAT-lite. This PR is based on fa3a855 (presently the latest commit in #27) and adds the newer version of access-generic-tracers.

Other components are kept the same, i.e:
- The UM uses the head of the [dev-access-esm1.6 branch](https://github.com/ACCESS-NRI/UM7)
- Iceberg fluxes are included via the [update_DaveBi](https://github.com/ACCESS-NRI/cice4/tree/update_DaveBi) branch of CICE4




---
:rocket: The latest prerelease `access-esm1p6/pr31-4` at 3ccb647aa2627345a412aabfc0cbe2dc5cc58bc5 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/31#issuecomment-2702615555 :rocket:



