### PR TITLE
Fake PR to test new FMS fork

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -47,7 +47,7 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2025.02.2'
     access-generic-tracers:
       require:
         - '@git.dev_2024.12.0'


### PR DESCRIPTION
A no-change PR to check CI builds ok with new FMS

---
:rocket: The latest prerelease `access-esm1p6/pr49-4` at 63e3a35b31b966ae9953bbafc79daa5b62392d5c is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/49#issuecomment-2681671575 :rocket:


