### PR TITLE
CABLE files reorganisation

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.2024.05.21=access-esm1.5'
     um7:
       require:
-        - '@git.8fd6949b1e520d5606f9cafee7a458b19f2eb171=access-esm1.6'
+        - '@git.322372ba5b2d72a833eaf9190cbd8594ddb0571a=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -73,7 +73,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2024.12.1'
           cice4: '{name}/2024.05.21-{hash:7}'
-          um7: '{name}/8fd6949b1e520d5606f9cafee7a458b19f2eb171-{hash:7}'
+          um7: '{name}/322372ba5b2d72a833eaf9190cbd8594ddb0571a-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
+        - '@git.dev_2024.08.14=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
@@ -26,7 +26,7 @@ spack:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
+        - '@git.access-esm1.5_2024.05.24=access-esm1.5'
     openmpi:
       require:
         - '@4.0.2'
@@ -41,10 +41,10 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.mom5-dev-2025.02.3'
+        - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.02.1'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -68,7 +68,7 @@ spack:
           access-esm1p6: '{name}/dev_2025.03.01'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/520d8ad7970aa490dac88d2fcd393dccc4616a22-{hash:7}'
-          mom5: '{name}/dev-2025.03.001-{hash:7}'
+          mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,6 +11,10 @@ spack:
   specs:
     - access-esm1p6@git.dev_2024.12.0
   packages:
+    # Direct ACCESS-NRI dependencies
+    # Note: some packages have branch-specific logic and hence can't use
+    # the usual '@git.DATE' calver (https://calver.org) format, instead
+    # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
         - '@git.dev_2024.08.14=access-esm1.6'
@@ -20,13 +24,15 @@ spack:
         - '@git.2024.05.21=access-esm1.5'
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.8fd6949b1e520d5606f9cafee7a458b19f2eb171=access-esm1.6'
+    # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
         - '@git.access-esm1.5_2024.05.24=access-esm1.5'
+    # Other dependencies
     openmpi:
       require:
         - '@4.0.2'
@@ -68,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/2024.05.21-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/file-reorg-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -73,7 +73,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2024.12.1'
           cice4: '{name}/2024.05.21-{hash:7}'
-          um7: '{name}/file-reorg-{hash:7}'
+          um7: '{name}/8fd6949b1e520d5606f9cafee7a458b19f2eb171-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.2024.12.1
+    - access-esm1p6@git.dev_2025.03.01
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -21,7 +21,7 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.da845aa74926626499d203d7b3e6cf2e3e240a57=access-esm1.6'
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -71,8 +71,8 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2024.12.1'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          access-esm1p6: '{name}/dev_2025.03.01'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/da845aa74926626499d203d7b3e6cf2e3e240a57-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.0
+    - access-esm1p6@git.dev_2025.03.01
   packages:
     mom5:
       require:
@@ -68,7 +68,7 @@ spack:
           access-esm1p6: '{name}/dev_2025.03.01'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/520d8ad7970aa490dac88d2fcd393dccc4616a22-{hash:7}'
-          mom5: '{name}/dev_2024.08.14-{hash:7}'
+          mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,10 +11,6 @@ spack:
   specs:
     - access-esm1p6@git.dev_2025.03.01
   packages:
-    # Direct ACCESS-NRI dependencies
-    # Note: some packages have branch-specific logic and hence can't use
-    # the usual '@git.DATE' calver (https://calver.org) format, instead
-    # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
         - '@git.dev_2024.08.14=access-esm1.6'
@@ -25,14 +21,12 @@ spack:
     um7:
       require:
         - '@git.da845aa74926626499d203d7b3e6cf2e3e240a57=access-esm1.6'
-    # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
         - '@git.access-esm1.5_2024.05.24=access-esm1.5'
-    # Other dependencies
     openmpi:
       require:
         - '@4.0.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.520d8ad7970aa490dac88d2fcd393dccc4616a22=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -67,7 +67,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.03.01'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
+          um7: '{name}/520d8ad7970aa490dac88d2fcd393dccc4616a22-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2024.12.0
+    - access-esm1p6@git.2024.12.1
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -54,7 +54,6 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-
     # Preferences for all packages
     all:
       require:
@@ -72,7 +71,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2024.12.0'
+          access-esm1p6: '{name}/2024.12.1'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/file-reorg-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
@@ -81,4 +80,4 @@ spack:
       root: $spack/../restricted/ukmo/release
     source_cache: $spack/../restricted/ukmo/source_cache
     build_stage:
-    - $TMPDIR/restricted/spack-stage
+      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.2024.05.21=access-esm1.5'
     um7:
       require:
-        - '@git.322372ba5b2d72a833eaf9190cbd8594ddb0571a=access-esm1.6'
+        - '@git.da845aa74926626499d203d7b3e6cf2e3e240a57=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -73,7 +73,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2024.12.1'
           cice4: '{name}/2024.05.21-{hash:7}'
-          um7: '{name}/322372ba5b2d72a833eaf9190cbd8594ddb0571a-{hash:7}'
+          um7: '{name}/da845aa74926626499d203d7b3e6cf2e3e240a57-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.da845aa74926626499d203d7b3e6cf2e3e240a57=access-esm1.6'
+        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -67,7 +67,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.03.01'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/da845aa74926626499d203d7b3e6cf2e3e240a57-{hash:7}'
+          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
This build should not change results. Only uses files in a different place. Used to check the movement of files doesn't break the build and doesn't break the run.

---
:rocket: The latest prerelease `access-esm1p6/pr52-7` at 800ea28edce726f0fe4d7b087d6ee30c3106f2d6 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/52#issuecomment-2716270139 :rocket:







