### PR TITLE
Update ifort to a recent version that is available on other systems

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.002"
+    "spack-packages": "2025.04.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -49,6 +49,9 @@ spack:
       require:
         - '@git.2017.12.0'
 
+    gcc-runtime:
+      require:
+        - '%gcc'
     # Preferences for all packages
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,12 +9,11 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+    - access-esm1p6@git.dev_2025.05.000
   packages:
     mom5:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
-        - '+access-gtracers'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
@@ -69,7 +68,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.04.000'
+          access-esm1p6: '{name}/dev_2025.05.000'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -52,7 +52,7 @@ spack:
     # Preferences for all packages
     all:
       require:
-        - '%intel@19.0.3.199'
+        - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:


### PR DESCRIPTION
* Leonardo and Setonix had issues with openmpi 4.0.2 when building ACCESS-OM2.
* Update ifort to a recent version that is available on other systems.

---
:rocket: The latest prerelease `access-esm1p6/pr53-22` at ca6862956061f8a8e54505d559968cab859c1afc is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/53#issuecomment-2844123521 :rocket:


























