### PR TITLE
Component updates to work with preindustrial+concentrations config

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.12.0"
+    "spack-packages": "2025.03.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.03.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,11 +9,11 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2024.12.0
+    - access-esm1p6@git.dev_2025.03.0
   packages:
     mom5:
       require:
-        - '@git.dev_2024.08.14=access-esm1.6'
+        - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
@@ -41,10 +41,10 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.mom5-dev-2025.02.3'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev-2025.02.1'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -66,10 +66,10 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2024.12.0'
+          access-esm1p6: '{name}/dev_2025.03.0'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/dev_2024.08.14-{hash:7}'
+          mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.03.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.update_DaveBi=access-esm1.5'
+        - '@git.370e61e8a21e75e3bbcbea7effce55a58e398112=access-esm1.5'
     um7:
       require:
         - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.03.0'
-          cice4: '{name}/update_DaveBi-{hash:7}'
+          cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5_2024.05.24=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     openmpi:
       require:
         - '@4.0.2'


### PR DESCRIPTION
It was brought up in our stand-up meeting today that the `spack.yaml` in the `main` branch isn't compatible with the current [`dev-preindustrial+concentrations`](https://github.com/ACCESS-NRI/access-esm1.6-configs/tree/8dc61da31d8c646aa6e23d600876b68370221e5f) configuration. This is because that configuration is currently using a [prerelease deployment](https://github.com/ACCESS-NRI/access-esm1.6-configs/blob/8dc61da31d8c646aa6e23d600876b68370221e5f/config.yaml#L25-L29) that uses a more recent version of WOMBATlite than is currently in the `main` branch.

The expectation was that the `main` branch `spack.yaml` should be compatible with the [`dev-preindustrial+concentrations`](https://github.com/ACCESS-NRI/access-esm1.6-configs/tree/8dc61da31d8c646aa6e23d600876b68370221e5f) configuration. ~This PR updates WOMBATlite and related components so that it is.~ Actually, it doesn't. It updates WOMBATlite and related components to the latest development versions. A small corresponding change will need to be made to the configuration for compatibility due to the addition of a couple more tracers.

I've also updated CICE to use the `update_DaveBi` branch. Are there any other updates we want to include, e.g. UM? @ccarouge, @blimlim

---
:rocket: The latest prerelease `access-esm1p6/pr54-1` at c665ee2c52ec3d61e07c0db6236bb35a2d8ad2bc is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/54#issuecomment-2696121840 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr54-6` at 094d1cbf9f4f42c5f28bb9dff29ade0d3aec5bd9 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/54#issuecomment-2712512836 :rocket:





