### PR TITLE
Test branch with halo fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.0
+    - access-esm1p6@git.2025.03.1=null
   packages:
     mom5:
       require:
@@ -49,7 +49,6 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-
     # Preferences for all packages
     all:
       require:
@@ -67,7 +66,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.0'
+          access-esm1p6: '{name}/2025.03.1'
           cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
@@ -76,4 +75,4 @@ spack:
       root: $spack/../restricted/ukmo/release
     source_cache: $spack/../restricted/ukmo/source_cache
     build_stage:
-    - $TMPDIR/restricted/spack-stage
+      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,9 +18,10 @@ spack:
     cice4:
       require:
         - '@git.370e61e8a21e75e3bbcbea7effce55a58e398112=access-esm1.5'
+    # 88-exner_theta-halo-fix
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.11d6a1ff486e8b25b75cb4357ab8d82073e5810d=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'


### PR DESCRIPTION
Test deployment of https://github.com/ACCESS-NRI/UM7/tree/88-exner_theta-halo-fix

---
:rocket: The latest prerelease `access-esm1p6/pr58-2` at 6a1a5151bc0f03c9630e5a544e980aa073e93fb1 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/58#issuecomment-2722909758 :rocket:


