### PR TITLE
spack.yaml: update cice4 hash to build with ifort 2021.10.0

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.0
+    - access-esm1p6@git.dev_2025.03.1
   packages:
     mom5:
       require:
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.370e61e8a21e75e3bbcbea7effce55a58e398112=access-esm1.5'
+        - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
         - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
@@ -66,7 +66,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.0'
+          access-esm1p6: '{name}/dev_2025.03.1'
           cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'


### PR DESCRIPTION
* Had to re-apply "Fix syntax error by removing continuation" commit to the cice4 repository because the commit after it reverted the fix.

---
:rocket: The latest prerelease `access-esm1p6/pr59-2` at 6a74aa38fd3438a8b7a76f27039f6fff09acf928 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/59#issuecomment-2731668984 :rocket:

