### PR TITLE
Temporary: Executables for decomposition reproducibility tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@v4
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p6
     permissions:
       contents: write
       # Required because later workflows also handle on.pull_request trigger

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.002"
+    "spack-packages": "2024.12.0"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.0
+    - 'access-esm1p6@git.dev_2025.03.0'
   packages:
   mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e=access-esm1.6'
+        - '@git.ef7bce300a148e52b52cc16e5eece8299b1cc0dc=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e-{hash:7}'
+          um7: '{name}/ef7bce300a148e52b52cc16e5eece8299b1cc0dc-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.5d492f3f805c3262166fc67fe656a1a043613cac=access-esm1.6'
+        - '@git.70b173e38c1c6f523e7cb7c61f3767f3c7d01671=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5d492f3f805c3262166fc67fe656a1a043613cac-{hash:7}'
+          um7: '{name}/70b173e38c1c6f523e7cb7c61f3767f3c7d01671-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # cc732bb 
     um7:
       require:
-        - '@git.snminBug=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
+        - '@git.75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
+          um7: '{name}/75f8304f559f8bd7ee9a5c02ac7fb87a96bc3e5e-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,10 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # cc732bb 
+    # 
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.snminBug=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/snminBug-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,10 +11,6 @@ spack:
   specs:
     - access-esm1p6@git.dev_2024.12.0
   packages:
-    # Direct ACCESS-NRI dependencies
-    # Note: some packages have branch-specific logic and hence can't use
-    # the usual '@git.DATE' calver (https://calver.org) format, instead
-    # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
         - '@git.dev_2024.08.14=access-esm1.6'
@@ -27,14 +23,12 @@ spack:
     um7: 
       require:
         - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
-    # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
         - '@git.access-esm1.5_2024.05.24=access-esm1.5'
-    # Other dependencies
     openmpi:
       require:
         - '@4.0.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.ef7bce300a148e52b52cc16e5eece8299b1cc0dc=access-esm1.6'
+        - '@git.fec66db8f63d9a784ec435703a63983d6d2119ee=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/ef7bce300a148e52b52cc16e5eece8299b1cc0dc-{hash:7}'
+          um7: '{name}/-fec66db8f63d9a784ec435703a63983d6d2119ee{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,8 +25,7 @@ spack:
     # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
     um7:
       require:
-        - '@git.snminBug=access-esm1.6'
-        # - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,8 +75,8 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-{hash:7}'
-          #um7: '{name}/dev-access-esm1.6-{hash:7}'
+          #um7: '{name}/snminBug-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 
+    # snmin=1.0 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
+        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7-debug=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/22-land-parameters-in-code-{hash:7}'
+          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
+    # 1cd51aa - read params from nml files 
     um7:
       require:
         - '@git.add-user-switches_draft2=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -66,7 +66,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.0'
+          access-esm1p6: '{name}/dev_2025.03.0-{hash:7}'
           cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.45d2c0f934b460d09619139488288747945499ab=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # snmin=0.1 
+    # USE snmin directly from runtime_opts mod
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -46,7 +46,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.2'
+        - '@git.dev_2025.01.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,6 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
+    # Root fractions revised by rml
     um7:
       require:
         - '@git.RevisedRootFractions=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # read params from nml files fix bug # 9ad2fc0..ecc3524
+    # read params from nml files fix bug # 5da9977 
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/-fec66db8f63d9a784ec435703a63983d6d2119ee{hash:7}'
+          um7: '{name}/fec66db8f63d9a784ec435703a63983d6d2119ee-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.8994b601c003ebaaaf344797daf33246255c2c9d=access-esm1.6'
+        - '@git.5d492f3f805c3262166fc67fe656a1a043613cac=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/8994b601c003ebaaaf344797daf33246255c2c9d-{hash:7}'
+          um7: '{name}/5d492f3f805c3262166fc67fe656a1a043613cac-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,11 +22,12 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # read params from nml files fix bug # 5da9977 
+    
+    # branch = 22-land-parameters-in-code
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.22-land-parameters-in-code=access-esm1.6'
+        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,8 +26,7 @@ spack:
     # branch = 22-land-parameters-in-code
     um7: 
       require:
-        #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.4fa79c73652f19f7e89ceba0890571187b86f989=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/4fa79c73652f19f7e89ceba0890571187b86f989-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # snmin=0.1 
     um7:
       require:
-        - '@git.snminBug=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.fec66db8f63d9a784ec435703a63983d6d2119ee=access-esm1.6'
+        - '@git.4fa79c73652f19f7e89ceba0890571187b86f989=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/fec66db8f63d9a784ec435703a63983d6d2119ee-{hash:7}'
+          um7: '{name}/4fa79c73652f19f7e89ceba0890571187b86f989-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,11 +13,11 @@ spack:
   packages:
   mom5:
       require:
-        - '@git.dev_2024.08.14=access-esm1.6'
+        - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.update_DaveBi=access-esm1.5'
+        - '@git.370e61e8a21e75e3bbcbea7effce55a58e398112=access-esm1.5'
     um7:
       require:
         - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
@@ -44,7 +44,7 @@ spack:
         - '@git.mom5-dev-2025.02.3'
     access-generic-tracers:
       require:
-        - '@git.dev_2025.01.2'
+        - '@git.dev-2025.02.1'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     um7:
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.test_2da305=access-esm1.6'
+        - '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/test_2da305-{hash:7}'
+          um7: '{name}/22-land-parameters-in-code-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -76,6 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
+          um7: '{name}/snminBug-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,8 +25,8 @@ spack:
     # 1cd51aa - read params from nml files redux 
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
-        #- '@git.22-land-parameters-in-code=access-esm1.6'
+        #- '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/22-land-parameters-in-code-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,10 +23,10 @@ spack:
       require:
         - '@git.update_DaveBi=access-esm1.5'
     
-    # branch = 22-land-parameters-in-code
+    #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.8b6bac6be230aa505229bb01e17e641e5aa90230=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/8b6bac6be230aa505229bb01e17e641e5aa90230-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod
+    # USE snmin directly from runtime_opts mod && snmin = 1.0
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,10 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # Root fractions revised by rml
+    # 2da3053c674c44cc683bcc4837846d7b44a4cd30
     um7:
       require:
-        - '@git.RevisedRootFractions=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/RevisedRootFractions-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/RevisePastWeek-{hash:7}'
+          um7: '{name}/RevisedRootFractions-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.45d2c0f934b460d09619139488288747945499ab=access-esm1.6'
+        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.RevisePastWeek=access-esm1.6'
+        - '@git.RevisedRootFractions=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.8b6bac6be230aa505229bb01e17e641e5aa90230=access-esm1.6'
+        - '@git.dee363e6329af3d2680b3269c329183fc1ddeaad=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     um7:
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.22-land-parameters-in-code=access-esm1.6'
+        - '@git.test_2da305=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/22-land-parameters-in-code-{hash:7}'
+          um7: '{name}/test_2da305-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,8 +22,8 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # read params from nml files fix bug 
-    um7:
+    # read params from nml files fix bug # 9ad2fc0..ecc3524
+    um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
         - '@git.22-land-parameters-in-code=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.70b173e38c1c6f523e7cb7c61f3767f3c7d01671=access-esm1.6'
+        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/70b173e38c1c6f523e7cb7c61f3767f3c7d01671-{hash:7}'
+          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/snminBug-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          #um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.dee363e6329af3d2680b3269c329183fc1ddeaad=access-esm1.6'
+        - '@git.8994b601c003ebaaaf344797daf33246255c2c9d=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dee363e6329af3d2680b3269c329183fc1ddeaad-{hash:7}'
+          um7: '{name}/8994b601c003ebaaaf344797daf33246255c2c9d-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # snmin=1.0 
+    # snmin=0.1 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,8 @@ spack:
     # 1cd51aa - read params from nml files redux 
     um7:
       require:
-        - '@git.22-land-parameters-in-code=access-esm1.6'
+        - '@git.dev-access-esm1.6=access-esm1.6'
+        #- '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/22-land-parameters-in-code-{hash:7}'
+          um7: '{name}/dev-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # 2da3053c674c44cc683bcc4837846d7b44a4cd30
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.snminBug=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/snminBug-access-esm1.6-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 1.0
+    # USE snmin directly from runtime_opts mod && snmin = 0.1
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # be2f3cb 
+    # cc732bb 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.add-user-switches_draft2=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,8 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          #um7: '{name}/snminBug-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/add-user-switches_draft2-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 1cd51aa - read params from nml files 
+    # 1cd51aa - read params from nml files redux 
     um7:
       require:
         - '@git.22-land-parameters-in-code=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 1cd51aa - read params from nml files redux 
+    # read params from nml files fix bug 
     um7:
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
     # 1cd51aa - read params from nml files 
     um7:
       require:
-        - '@git.add-user-switches_draft2=access-esm1.6'
+        - '@git.22-land-parameters-in-code=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/add-user-switches_draft2-{hash:7}'
+          um7: '{name}/22-land-parameters-in-code-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,13 +11,13 @@ spack:
   specs:
     - access-esm1p6@git.dev_2025.03.0
   packages:
-    mom5:
+  mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
+        - '@git.dev_2024.08.14=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.370e61e8a21e75e3bbcbea7effce55a58e398112=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
@@ -44,7 +44,7 @@ spack:
         - '@git.mom5-dev-2025.02.3'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.02.1'
+        - '@git.dev_2025.01.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,8 @@ spack:
     # USE snmin directly from runtime_opts mod && snmin = 0.1
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.snminBug=access-esm1.6'
+        # - '@git.dev-access-esm1.6=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -75,7 +75,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/snminBug-access-esm1.6-{hash:7}'
+          um7: '{name}/snminBug-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,23 +2,25 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-#
+
 # Build with:
 # - UM7 from dev-access-esm1.6 branch
 # - MOM5 from development branch
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - 'access-esm1p6@git.dev_2025.03.0'
+    - access-esm1p6@git.dev_2024.12.0
   packages:
-  mom5:
+    mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
+        - '@git.dev_2024.08.14=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.370e61e8a21e75e3bbcbea7effce55a58e398112=access-esm1.5'
-    um7:
+        - '@git.update_DaveBi=access-esm1.5'
+    
+    #branch = dev-access-esm1.6 
+    um7: 
       require:
         - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
     gcom4:
@@ -26,7 +28,7 @@ spack:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
+        - '@git.access-esm1.5_2024.05.24=access-esm1.5'
     openmpi:
       require:
         - '@4.0.2'
@@ -41,10 +43,10 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.mom5-dev-2025.02.3'
+        - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.02.1'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -66,10 +68,10 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.0'
-          cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
+          access-esm1p6: '{name}/dev_2024.12.0'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
-          mom5: '{name}/dev-2025.03.001-{hash:7}'
+          mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.RevisePastWeek-access-esm1.6=access-esm1.6'
+        - '@git.RevisePastWeek=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/RevisePastWeek-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 1.0 5f4df5d93f1d3f702a4cfe69290cf6a87996cc61
+    # USE snmin directly from runtime_opts mod && snmin = 1.0 4ed8b49cf4f3cd018bb72eceafeac5f3fcfa2e0d 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -66,7 +66,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.0-{hash:7}'
+          access-esm1p6: '{name}/dev_2025.03.0'
           cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
+          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-debug-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # 2da3053c674c44cc683bcc4837846d7b44a4cd30
+    # be2f3cb 
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     #branch = dev-access-esm1.6 
     um7: 
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -70,7 +70,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
+          um7: '{name}/7288a51bf7aae3d2836aca674a1ae7ed15796e01-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
     um7: 
       require:
         #- '@git.dev-access-esm1.6=access-esm1.6'
-        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7-debug=access-esm1.6'
+        - '@git.5da9977a0221a29f493454758f3617ad59d8c2d7=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -77,7 +77,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-debug-{hash:7}'
+          um7: '{name}/5da9977a0221a29f493454758f3617ad59d8c2d7-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
     cice4:
       require:
         - '@git.update_DaveBi=access-esm1.5'
-    # USE snmin directly from runtime_opts mod && snmin = 0.1
+    # USE snmin directly from runtime_opts mod && snmin = 1.0 5f4df5d93f1d3f702a4cfe69290cf6a87996cc61
     um7:
       require:
         - '@git.snminBug=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,6 +11,10 @@ spack:
   specs:
     - access-esm1p6@git.dev_2024.12.0
   packages:
+    # Direct ACCESS-NRI dependencies
+    # Note: some packages have branch-specific logic and hence can't use
+    # the usual '@git.DATE' calver (https://calver.org) format, instead
+    # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
         - '@git.dev_2024.08.14=access-esm1.6'
@@ -20,13 +24,15 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.RevisePastWeek-access-esm1.6=access-esm1.6'
+    # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
         - '@git.access-esm1.5_2024.05.24=access-esm1.5'
+    # Other dependencies
     openmpi:
       require:
         - '@4.0.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -76,7 +76,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/8b6bac6be230aa505229bb01e17e641e5aa90230-{hash:7}'
+          um7: '{name}/dee363e6329af3d2680b3269c329183fc1ddeaad-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
Previous tests when swapping to Sapphire Rapids nodes revealed the UM did not reproduce across processor decompositions. This has been fixed in https://github.com/ACCESS-NRI/UM7/pull/91. 

This PR includes an updated UM version with the above fix, and the prerelease executables will be used to run some sanity checks before swapping the configurations over to sapphire rapids. After the tests, this PR will be closed.