### PR TITLE
Temporary executables for decomposition reproducibility tests

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.03.1'
           cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
-          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
+          um7: '{name}/7288a51bf7aae3d2836aca674a1ae7ed15796e01-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
Previous tests when swapping to Sapphire Rapids nodes revealed the UM did not reproduce across processor decompositions. This has been fixed in https://github.com/ACCESS-NRI/UM7/pull/91.

This PR includes an updated UM version with the above fix, and the prerelease executables will be used to run some sanity checks before swapping the configurations over to sapphire rapids. After the tests, this PR will be closed.

---
:rocket: The latest prerelease `access-esm1p6/pr62-1` at 36d5cd915f9e6ed662922a5fd24af29cb2a6f88f is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/62#issuecomment-2735047870 :rocket:
