### PR TITLE
Update spack.yaml for UM with init compile flags

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.06c5a1ef7e4ac8cfc828cb935e9d5aab539853ba=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'


### PR DESCRIPTION
Added variable initialisation compile flags to the UM to test non-determinism hypothesis.

This branch is not intended to be merged. Testing hypothesis of garbage memory being written as cause of non-determinism by setting scalars and arrays to have value 0 on initialisation.

---
:rocket: The latest prerelease `access-esm1p6/pr63-1` at 8d2c6da901b1dd49118aa40841243c2448694ce9 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/63#issuecomment-2735048080 :rocket:
