### PR TITLE
spack.yaml: update openmpi to 4.1.5

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.2
+    - access-esm1p6@git.dev_2025.03.3
   packages:
     mom5:
       require:
@@ -29,7 +29,7 @@ spack:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     openmpi:
       require:
-        - '@4.0.2'
+        - '@4.1.5'
     netcdf-c:
       require:
         - '@4.7.4'
@@ -66,7 +66,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.2'
+          access-esm1p6: '{name}/dev_2025.03.3'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'


### PR DESCRIPTION
Check if just updating openmpi 4.1.5 maintains reproducibility.

---
:rocket: The latest prerelease `access-esm1p6/pr64-2` at c1e8fe44145e72d4a24d9eb4a032d45b063140dd is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/64#issuecomment-2742298232 :rocket:

