### PR TITLE
Update cice hash in projection

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.1
+    - access-esm1p6@git.dev_2025.03.2
   packages:
     mom5:
       require:
@@ -66,8 +66,8 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.1'
-          cice4: '{name}/370e61e8a21e75e3bbcbea7effce55a58e398112-{hash:7}'
+          access-esm1p6: '{name}/dev_2025.03.2'
+          cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:


### PR DESCRIPTION
Small PR to update the cice hash in the projections to match the hash in the packages section

---
:rocket: The latest prerelease `access-esm1p6/pr65-1` at 3f55447a6a58674f28721cd7cd33db26aa9759d5 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/65#issuecomment-2739500207 :rocket:

