### PR TITLE
Add SOURCE argument to ALLOCATE calls in CASA

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.1f96b4da17051a892f3c5c509d8ea24b44d633aa=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -67,7 +67,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2025.03.4'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
+          um7: '{name}/1f96b4da17051a892f3c5c509d8ea24b44d633aa-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.8651faf497c4b007ff027f86fcdd4ba5309edbb3=access-esm1.6'
+        - '@git.29ef93a054f0eeaf0f98c783757bdd29785f3b5b=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -67,7 +67,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2025.03.4'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/8651faf497c4b007ff027f86fcdd4ba5309edbb3-{hash:7}'
+          um7: '{name}/29ef93a054f0eeaf0f98c783757bdd29785f3b5b-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.2025.03.4=null
+    - access-esm1p6@git.dev_2025.03.4
   packages:
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.3
+    - access-esm1p6@git.2025.03.4=null
   packages:
     mom5:
       require:
@@ -48,7 +48,6 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-
     # Preferences for all packages
     all:
       require:
@@ -66,7 +65,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.3'
+          access-esm1p6: '{name}/2025.03.4'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
           um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
@@ -75,4 +74,4 @@ spack:
       root: $spack/../restricted/ukmo/release
     source_cache: $spack/../restricted/ukmo/source_cache
     build_stage:
-    - $TMPDIR/restricted/spack-stage
+      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.1f96b4da17051a892f3c5c509d8ea24b44d633aa=access-esm1.6'
+        - '@git.8651faf497c4b007ff027f86fcdd4ba5309edbb3=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -67,7 +67,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2025.03.4'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/1f96b4da17051a892f3c5c509d8ea24b44d633aa-{hash:7}'
+          um7: '{name}/8651faf497c4b007ff027f86fcdd4ba5309edbb3-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.4
+    - access-esm1p6@git.2025.03.5=null
   packages:
     mom5:
       require:
@@ -65,7 +65,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.03.4'
+          access-esm1p6: '{name}/2025.03.5'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
           um7: '{name}/29ef93a054f0eeaf0f98c783757bdd29785f3b5b-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'


### PR DESCRIPTION
There are some CASA variables which are ALLOCATED but not assigned before being written as part of the UM7 diagnostics. This caused non-deterministic differences in the output and therefore spurious reproducibility failures. As a temporary fix, all CASA variables are initialised using the ```SOURCE``` keyword argument of ```ALLOCATE```. This will prevent any other false negatives in bitwise reproducibility, while the core issue (CASA variables being written before anything meaningful is done to them) is fixed.

---
:rocket: The latest prerelease `access-esm1p6/pr68-4` at 328d08e9b09234aeb80186dedbd4b81abe0b3bf5 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/68#issuecomment-2760376069 :rocket:





