### PR TITLE
Update UM version for reproducibility accross decompositions

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.3
+    - access-esm1p6@git.dev_2025.03.4
   packages:
     mom5:
       require:
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -66,9 +66,9 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.3'
+          access-esm1p6: '{name}/dev_2025.03.4'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
+          um7: '{name}/7288a51bf7aae3d2836aca674a1ae7ed15796e01-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
This PR updates the UM commit to [7288a51](https://github.com/ACCESS-NRI/UM7/commit/7288a51bf7aae3d2836aca674a1ae7ed15796e01). This adds a fix for https://github.com/ACCESS-NRI/UM7/issues/88, which making the UM deterministic across different processor decompositions.

---
:rocket: The latest prerelease `access-esm1p6/pr69-1` at 256838baf524b4cccfe68100dea0a9fe60a043ae is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/69#issuecomment-2753042156 :rocket:

