### PR TITLE
Temporary tests for comparing UM commits

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf=access-esm1.6'
+        - '@git.43d3859578afddca82267ba2f275b416f3e2a41a=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.03.3'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/86a4e1fc37cb1d6fc1dae536deb5c0bd104506bf-{hash:7}'
+          um7: '{name}/43d3859578afddca82267ba2f275b416f3e2a41a-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
     um7:
       require:
-        - '@git.43d3859578afddca82267ba2f275b416f3e2a41a=access-esm1.6'
+        - '@git.184164b5b866e0cdb6f871a4a2342f29a5c5f974=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.03.3'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/43d3859578afddca82267ba2f275b416f3e2a41a-{hash:7}'
+          um7: '{name}/184164b5b866e0cdb6f871a4a2342f29a5c5f974-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr71-2` at 130928d7ef70d7af1a10861cf0a8f88e0a2f36e2 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/71#issuecomment-2767843649 :rocket:

