### PR TITLE
Added cascadelake arch and the sanitizer flags with classic intel

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -15,22 +15,24 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all -init=snan -init=array -init=huge"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all -init=snan -init=array -init=huge"'
 
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
     openmpi:
       require:
         - '@4.1.5'
@@ -46,12 +48,15 @@ spack:
     access-fms:
       require:
         - '@git.mom5-2025.04.001'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.04.001'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
     access-mocsy:
       require:
         - '@git.2017.12.0'
+        - 'fflags="-xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
 
     # Preferences for all packages
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -58,7 +58,7 @@ spack:
       require:
         # - '%intel@19.0.3.199'
         - '%intel@2021.10.0'
-        - 'target=cascadelake'
+        - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6
+    - access-esm1p6@latest
   packages:
     mom5:
       require:
@@ -79,7 +79,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.4'
+          access-esm1p6: '{name}/latest'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
           um7: '{name}/7288a51bf7aae3d2836aca674a1ae7ed15796e01-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -65,7 +65,7 @@ spack:
     # Preferences for all packages
     all:
       require:
-        - '%intel@19.0.3.199'
+        - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.4
+    - access-esm1p6
   packages:
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,12 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
+        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+
     um7:
       require:
         - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
+        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge -flto"'
+        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -flto"'
+        - 'ldflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -flto -fuse-ld=lld"'
+
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,15 +15,15 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all -init=snan -init=array -init=huge"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all"'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
-        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all -init=snan -init=array -init=huge"'
 
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,24 +15,15 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
-        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
-        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
-
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
     cice4:
       require:
-        - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
-        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
-        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
-
+        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
     um7:
       require:
-        - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
-        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
-        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
-        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
-        - 'ldflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.6'
+        - 'fflags="-fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
 
     gcom4:
       require:
@@ -54,10 +45,10 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.mom5-dev-2025.02.3'
+        - '@git.mom5-2025.04.001'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.02.1'
+        - '@git.dev-2025.04.001'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -65,6 +56,7 @@ spack:
     # Preferences for all packages
     all:
       require:
+        # - '%intel@19.0.3.199'
         - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
@@ -80,8 +72,8 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/latest'
-          cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/7288a51bf7aae3d2836aca674a1ae7ed15796e01-{hash:7}'
+          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,10 +29,10 @@ spack:
     um7:
       require:
         - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
-        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge -flto"'
-        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -flto"'
-        - 'ldflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=cascadelake -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'cflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+        - 'cxxflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
+        - 'ldflags="-march=cascadelake -mtune=cascadelake -fprotect-parens"'
 
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -58,10 +58,16 @@ spack:
       require:
         # - '%intel@19.0.3.199'
         - '%intel@2021.10.0'
-        - 'target=x86_64_v4'
+        - 'target=cascadelake'
   view: true
   concretizer:
     unify: true
+    targets:
+        # Determine whether we want to target specific or generic
+        # microarchitectures. Valid values are: "microarchitectures" or "generic".
+        # An example of "microarchitectures" would be "skylake" or "bulldozer",
+        # while an example of "generic" would be "aarch64" or "x86_64_v4".
+        granularity: microarchitectures
   modules:
     default:
       tcl:


### PR DESCRIPTION
Do not merge

Testing the builds with classic intel and the compiler flags. Similar builds with oneAPI have a runtime crash for the ESM1.6 PI config.

---
:rocket: The latest prerelease `access-esm1p6/pr74-9` at 1b031547501eec80e01df687728c012c863cfb73 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/74#issuecomment-2893141275 :rocket:










