### PR TITLE
Update versions for new spinup run

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.03.4
+    - access-esm1p6@git.dev_2025.04.000
   packages:
     mom5:
       require:
@@ -17,10 +17,10 @@ spack:
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
-        - '@git.7288a51bf7aae3d2836aca674a1ae7ed15796e01=access-esm1.6'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -41,10 +41,10 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.mom5-dev-2025.02.3'
+        - '@git.mom5-2025.04.001'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.02.1'
+        - '@git.dev-2025.04.001'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -66,9 +66,9 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.03.4'
-          cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/7288a51bf7aae3d2836aca674a1ae7ed15796e01-{hash:7}'
+          access-esm1p6: '{name}/dev_2025.04.000'
+          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
Closes #73 

This PR creates a new release for the next set of ESM1.6 spinup simulations. It is largely based on [PR43-25](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/43#issuecomment-2771423820), however uses a newer version of WOMBAT-lite.

Notes:
- The CICE4 tag [access-esm1.6-2025.04.000](https://github.com/ACCESS-NRI/cice4/releases/tag/access-esm1.6-2025.04.000) points to the same commit ([b51e352
](https://github.com/ACCESS-NRI/cice4/commit/b51e3529bd78fd852760e348983e2334341f861d)) as in PR43-25.
- The UM tag [access-esm1.6-2025.04.000](https://github.com/ACCESS-NRI/UM7/releases/tag/access-esm1.6-2025.04.000) points to the same commit  ([a294b37](https://github.com/ACCESS-NRI/UM7/commit/a294b37eb5f89c1358b802dfbb080437aead0fb2)) as PR43-25.
- access-generic-tracers and access-fms have been updated to newer versions compared to PR43-35.




---
:rocket: The latest prerelease `access-esm1p6/pr75-1` at 8dfdc994ca6fe4aa7015f2b93cefcf59501ec478 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/75#issuecomment-2785384048 :rocket:
