### PR TITLE
Temporary: Try to find UM commit used in spinup

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2025.01.0'
+        - '@git.dev_2025.01.1'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.dev-access-esm1.6=access-esm1.6'
+        - '@git.5103908862af07c3be4a16eab12c3a404baf3e6c=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/dev-access-esm1.6-{hash:7}'
+          um7: '{name}/5103908862af07c3be4a16eab12c3a404baf3e6c-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
         - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
-        - '@git.5103908862af07c3be4a16eab12c3a404baf3e6c=access-esm1.6'
+        - '@git.457d1da26332a78a2418c888f7f74d71c81f69bd=access-esm1.6'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
-          um7: '{name}/5103908862af07c3be4a16eab12c3a404baf3e6c-{hash:7}'
+          um7: '{name}/457d1da26332a78a2418c888f7f74d71c81f69bd-{hash:7}'
           mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2025.01.1'
+        - '@git.dev_2025.01.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.update_DaveBi=access-esm1.6'
+        - '@git.dev_2024.08.14=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.wombatlite-sinking'
+        - '@git.dev_2024.12.0'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -75,7 +75,7 @@ spack:
           access-esm1p6: '{name}/dev_2024.12.0'
           cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/update_DaveBi-{hash:7}'
+          mom5: '{name}/dev_2024.08.14-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,11 +17,11 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.dev_2024.08.14=access-esm1.6'
+        - '@git.update_DaveBi=access-esm1.6'
         - '+access-gtracers'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.update_DaveBi=access-esm1.5'
     um7:
       require:
         - '@git.dev-access-esm1.6=access-esm1.6'
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.wombatlite-sinking'
     access-mocsy:
       require:
         - '@git.2017.12.0'
@@ -73,9 +73,9 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/update_DaveBi-{hash:7}'
           um7: '{name}/dev-access-esm1.6-{hash:7}'
-          mom5: '{name}/dev_2024.08.14-{hash:7}'
+          mom5: '{name}/update_DaveBi-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.2'
+        - '@git.dev_2025.01.0'
     access-mocsy:
       require:
         - '@git.2017.12.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,7 +50,7 @@ spack:
         - '@git.dev_2024.12.0'
     access-generic-tracers:
       require:
-        - '@git.dev_2024.12.0'
+        - '@git.dev_2024.12.2'
     access-mocsy:
       require:
         - '@git.2017.12.0'


### PR DESCRIPTION
The spinup run described [here](https://forum.access-hive.org.au/t/esm1-6-spin-up-experiments/4219) used UM executables built from a branch, making it difficult to know which commit of the code was used. Use this PR to try to figure this out.

Based on [this commit](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/31#issuecomment-2605908901)

---
:rocket: The latest prerelease `access-esm1p6/pr81-1` at aeadfef43deee780fcdea388d9751a7b781376a2 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/81#issuecomment-2819818575 :rocket:
