### PR TITLE
Fix CICE5 dump last option

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.6'
+        - '@git.2caadb2ed894134a98e339c472b3b4678c18d534=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/0b2d87220a847463cded92f181d49520b9bc25d8-{hash:7}'
+          cice5: '{name}/2caadb2ed894134a98e339c472b3b4678c18d534-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.5'
+        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.2caadb2ed894134a98e339c472b3b4678c18d534=access-esm1.6'
+        - '@git.ceedceda87c0ddeab51d8618710156d0641d62ed=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/2caadb2ed894134a98e339c472b3b4678c18d534-{hash:7}'
+          cice5: '{name}/ceedceda87c0ddeab51d8618710156d0641d62ed-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,15 +9,15 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+    - access-esm1p6@git.dev_2025.04.000 cice=5
   packages:
     mom5:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-    cice4:
+    cice5:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.5'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -62,12 +62,12 @@ spack:
       tcl:
         include:
           - access-esm1p6
-          - cice4
+          - cice5
           - um7
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          cice5: '{name}/0b2d87220a847463cded92f181d49520b9bc25d8-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:


### PR DESCRIPTION
Draft PR to test addition of `dump_last` option to CICE5 in ESM1.6

---
:rocket: The latest prerelease `access-esm1p6/pr89-2` at c758dde68eb1090cf507967df1d074c71c24793d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/89#issuecomment-2934935489 :rocket:

