### PR TITLE
Test cice5 without caltype

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.34a24887ae0a7930ca7ab7cc8b86a6a33bbb0901=access-esm1.6'
+        - '@git.4bfbf6be4149444cd22a23f944feef1e9bea124a=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/34a24887ae0a7930ca7ab7cc8b86a6a33bbb0901-{hash:7}'
+          cice5: '{name}/4bfbf6be4149444cd22a23f944feef1e9bea124a-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:


### PR DESCRIPTION
Test build with caltype removed. Part of https://github.com/ACCESS-NRI/cice5/issues/28

---
:rocket: The latest prerelease `access-esm1p6/pr90-14` at da3c54fa7019cc3f690d11b4a70b3c2274c7863d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/90#issuecomment-2965161630 :rocket:
















