### PR TITLE
Update to new UM with phenology changes

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+    - access-esm1p6@git.dev_2025.06.000
   packages:
     mom5:
       require:
@@ -20,7 +20,7 @@ spack:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.6'
+        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -66,9 +66,9 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.04.000'
+          access-esm1p6: '{name}/dev_2025.06.000'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
Closes #92 
Updates the UM to a new tag with changes required for future ESM1.6 simulations. The main change is the phenology update [here](https://github.com/ACCESS-NRI/UM7/pull/104).

This new executable will be used alongside the configuration changes in https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/133

---
:rocket: The latest prerelease `access-esm1p6/pr93-1` at bdbcff1abd4d92a8338d1d8004c32bb4258fe07f is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/93#issuecomment-2948295872 :rocket:

