### PR TITLE
Add CABLE as a library to UM7 instead of source code

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.002"
+    "spack-packages": "fdf7b754693217d41b0955e435d50c0e6395280f"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,24 +9,28 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+    - access-esm1p6@latest
   packages:
     mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
-        - '+access-gtracers'
+        - '@git.ad1e41e2f7687a09e82addf5edbcca18fdd43ed5=access-esm1.6'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.6'
+        - '@git.a2f2f0504a6d4a7d5d128d110d7eb725370d4ce7=access-esm1.6'
+    cable:
+      require:
+        - '@git.c069680d4796def94f075f6eb975923d6c345685=access-esm1.6'
+        - '+library+mpi'
+        - 'fflags="-i8 -r8"'
     gcom4:
       require:
-        - '@git.2024.05.28=access-esm1.5'
+        - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
+        - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
     openmpi:
       require:
         - '@4.1.5'
@@ -41,10 +45,10 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.mom5-2025.04.001'
+        - '@git.mom5-2025.05.000'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.04.001'
+        - '@git.dev-2025.05.001'
     access-mocsy:
       require:
         - '@git.2017.12.0'


### PR DESCRIPTION
This works adds CABLE as a library to the UM7 code, rather than the source files being copied from the CABLE repository and dumped in the UM7 repository.

This is to reduce code duplication and simplify the CABLE development process in coupled models. Contains changes to UM7, CABLE and the UM7 spack package.