### PR TITLE
cice5 + oneapi

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.002"
+    "spack-packages": "2025.05.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,79 +20,90 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:
       require:
+        '/qljzx7x'
         # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
-        - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/rjo4gre'
+        # - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
-        - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/4ahbikn'
+        # - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
-        - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/6quqwyb'
+        # - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
-        - '@git.mom5-2025.04.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/finlfac'
+        # - '@git.mom5-2025.04.001'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.04.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/z2t66eo'
+        # - '@git.dev-2025.04.001'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
-        - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/meqj55h'
+        # - '@git.2017.12.0'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
-        - '@4.1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/xid2pum'
+        # - '@4.1.5'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-c:
       require:
-        - '@4.7.4'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/dpqjhl3'
+        # - '@4.7.4'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-fortran:
       require:
-        - '@4.5.2'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/vqb6dyd'
+        # - '@4.5.2'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     hdf5:
       require:
-        - '@1.10.11'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        '/v7qxufc'
+        # - '@1.10.11'
+        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,91 +15,45 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
-
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
     um7:
       require:
         - '@git.ad219516fcbb5386739e3e07ab7fef6a54634034=access-esm1.6'
-        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -heap-arrays -assume nan_compares -assume ieee_compares -assume nominus0 -traceback"'
-        - 'cflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'cxxflags="-g3 -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld -heap-arrays"'
-
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-fms:
       require:
         - '@git.mom5-dev-2025.02.3'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
     access-generic-tracers:
       require:
         - '@git.dev-2025.02.1'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
-        - '@5.0.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
+        - '@4.1.5'
     netcdf-c:
       require:
-        - '@4.9.2'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
+        - '@4.7.4'
     netcdf-fortran:
       require:
-        - '@4.6.1'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-
+        - '@4.5.2'
     hdf5:
       require:
-        - '@1.14.3'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
-        - 'cflags="-g3 -xCORE-AVX2"'
-        - 'cxxflags="-g3 -xCORE-AVX2"'
+        - '@1.10.11'
 
     gcc-runtime:
       require:
@@ -109,12 +63,11 @@ spack:
       require:
         - '%gcc'
 
-
     # Preferences for all packages
     all:
       require:
         - '%oneapi@2025.0.4'
-        # - 'target=x86_64_v3'
+        - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,6 @@ spack:
     mom5:
       require:
         - '@git.ad1e41e2f7687a09e82addf5edbcca18fdd43ed5=access-esm1.6'
-        - '+access-gtracers'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -52,14 +51,14 @@ spack:
     access-fms:
       require:
         # '/finlfac'
-        - '@git.mom5-2025.04.001'
+        - '@git.mom5-2025.05.000'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
         # '/z2t66eo'
-        - '@git.dev-2025.04.001'
+        - '@git.dev-2025.05.001'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
-        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
-        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids,CORE-AVX2"'
-        - 'cflags="-march=cascadelake -axsapphirerapids,CORE-AVX2"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids,CORE-AVX2"'
+        - 'fflags="-march=cascadelake -axsapphirerapids"'
+        - 'cflags="-march=cascadelake -axsapphirerapids"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto"'
-        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto"'
-        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto"'
-        - 'ldflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -55,6 +55,14 @@ spack:
       require:
         - '@1.10.11'
 
+    gcc-runtime:
+      require:
+        - '%gcc'
+
+    glibc:
+      require:
+        - '%gcc'
+
     # Preferences for all packages
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,10 +30,10 @@ spack:
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
-        - 'cflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto"'
-        - 'cxxflags="-g -O2 -march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto"'
-        - 'ldflags="-g -O2 -march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto -fuse-ld=lld"'
+        - 'fflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'cxxflags="-g -O2 -march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'ldflags="-g -O2 -march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -119,8 +119,8 @@ spack:
         projections:
           access-esm1p6: '{name}/latest'
           cice5: '{name}/a0e238d50dfca346f171dc4273305b6a09e5d4a7-{hash:7}'
-          um7: '{name}/ad219516fcbb5386739e3e07ab7fef6a54634034-{hash:7}'
-          mom5: '{name}/oneapi-floatingpoint-fix-{hash:7}'
+          um7: '{name}/1ea43190add8627fb317906d257f278763b55125-{hash:7}'
+          mom5: '{name}/ad1e41e2f7687a09e82addf5edbcca18fdd43ed5-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from access-esm1.6 branch.
 spack:
   specs:
-    - 'access-esm1p6@latest cice=5 um=access-esm1.6'
+    - access-esm1p6@latest cice=5
   packages:
     mom5:
       require:
@@ -107,6 +107,10 @@ spack:
         - '%gcc'
 
     glibc:
+      require:
+        - '%gcc'
+        
+    zlib-ng:
       require:
         - '%gcc'
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,45 +15,83 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
         - '@git.ad219516fcbb5386739e3e07ab7fef6a54634034=access-esm1.6'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
         - '@git.mom5-dev-2025.02.3'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.02.1'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     access-mocsy:
       require:
         - '@git.2017.12.0'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
         - '@4.1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     netcdf-c:
       require:
         - '@4.7.4'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     netcdf-fortran:
       require:
         - '@4.5.2'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     hdf5:
       require:
         - '@1.10.11'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,8 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:
       require:
-        - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -46,13 +47,13 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
-        - '@git.mom5-dev-2025.02.3'
+        - '@git.mom5-2025.04.001'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.02.1'
+        - '@git.dev-2025.04.001'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -119,7 +120,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/latest'
-          cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
+          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           um7: '{name}/ad219516fcbb5386739e3e07ab7fef6a54634034-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
-        - '@git.ad219516fcbb5386739e3e07ab7fef6a54634034=access-esm1.6'
+        - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,60 +15,91 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g3 -O2 -xCORE-AVX2   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
-        - 'cflags="-g3 -O2 -xCORE-AVX2   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'cxxflags="-g3 -O2 -xCORE-AVX2 -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g3 -O2 -xCORE-AVX2  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
+        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'cxxflags="-g3 -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-fms:
       require:
         - '@git.mom5-dev-2025.02.3'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     access-generic-tracers:
       require:
         - '@git.dev-2025.02.1'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     access-mocsy:
       require:
         - '@git.2017.12.0'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
         - '@5.0.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-c:
       require:
         - '@4.9.2'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     netcdf-fortran:
       require:
         - '@4.6.1'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     hdf5:
       require:
         - '@1.14.3'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'cflags="-g3 -xCORE-AVX2"'
+        - 'cxxflags="-g3 -xCORE-AVX2"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from access-esm1.6 branch.
 spack:
   specs:
-    - access-esm1p6@latest cice=5
+    - 'access-esm1p6 cice=5 um=access-esm1.6'
   packages:
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 "'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 "'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 "'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,8 +13,7 @@ spack:
   packages:
     mom5:
       require:
-        # - '@git.dev-2025.03.001=access-esm1.6'
-        - '@git.68ba5781d56d690669293ac7fdcc8a453fac58f0=access-esm1.6'
+        - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
@@ -59,16 +58,17 @@ spack:
     # System-level packages
     openmpi:
       require:
-        - '@4.1.5'
+        - '@5.0.5'
+
     netcdf-c:
       require:
-        - '@4.7.4'
+        - '@4.9.2'
     netcdf-fortran:
       require:
-        - '@4.5.2'
+        - '@4.6.1'
     hdf5:
       require:
-        - '@1.10.11'
+        - '@1.14.3'
 
     gcc-runtime:
       require:
@@ -77,6 +77,7 @@ spack:
     glibc:
       require:
         - '%gcc'
+
 
     # Preferences for all packages
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,10 +30,10 @@ spack:
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto"'
-        - 'ldflags="-march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto -fuse-ld=lld"'
+        - 'fflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto"'
+        - 'cxxflags="-g -O2 -march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto"'
+        - 'ldflags="-g -O2 -march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -fno-optimize-sibling-calls -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.003c8a80bd223d2722b4aaca4174b3e3a21d87e6=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O2"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O1"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,14 +16,14 @@ spack:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
         - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
         - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
 
@@ -31,8 +31,8 @@ spack:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
         - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto -fuse-ld=lld"'
 
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -unroll"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -fprotect-parens -unroll"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -fprotect-parens -unroll"'
+        - 'fflags="g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
+        - 'cflags="g3 -xCORE-AVX2 -fprotect-parens -unroll"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g3 -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
-        - 'cflags="-g3 -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'cxxflags="-g3 -O2 -march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g3 -O2 -march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -O2 -xCORE-AVX2   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -O2 -xCORE-AVX2   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'cxxflags="-g3 -O2 -xCORE-AVX2 -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'ldflags="-g3 -O2 -xCORE-AVX2  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 "'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 "'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 "'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -83,7 +83,7 @@ spack:
     all:
       require:
         - '%oneapi@2025.0.4'
-        - 'target=x86_64_v4'
+        - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -103,7 +103,7 @@ spack:
     # Preferences for all packages
     all:
       require:
-      - '%oneapi@2025.0.4'
+      - '%oneapi@2025.02.000'
       - target=x86_64_v3
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,90 +20,90 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:
       require:
-        '/qljzx7x'
-        # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        # - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/qljzx7x'
+        - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
-        '/rjo4gre'
-        # - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/rjo4gre'
+        - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
-        '/4ahbikn'
-        # - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/4ahbikn'
+        - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
-        '/6quqwyb'
-        # - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/6quqwyb'
+        - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
-        '/finlfac'
-        # - '@git.mom5-2025.04.001'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/finlfac'
+        - '@git.mom5-2025.04.001'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
-        '/z2t66eo'
-        # - '@git.dev-2025.04.001'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/z2t66eo'
+        - '@git.dev-2025.04.001'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
-        '/meqj55h'
-        # - '@git.2017.12.0'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/meqj55h'
+        - '@git.2017.12.0'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
-        '/xid2pum'
-        # - '@4.1.5'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/xid2pum'
+        - '@4.1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-c:
       require:
-        '/dpqjhl3'
-        # - '@4.7.4'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/dpqjhl3'
+        - '@4.7.4'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-fortran:
       require:
-        '/vqb6dyd'
-        # - '@4.5.2'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/vqb6dyd'
+        - '@4.5.2'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     hdf5:
       require:
-        '/v7qxufc'
-        # - '@1.10.11'
-        # - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        # - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        # - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/v7qxufc'
+        - '@1.10.11'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.ad1e41e2f7687a09e82addf5edbcca18fdd43ed5=access-esm1.6'
         - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-          -traceback"
+          -traceback -fpe3"
         - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
         - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
     cice5:

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,9 +30,11 @@ spack:
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
-        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
-        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto"'
+        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto"'
+        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto"'
+        - 'ldflags="-march=sapphirerapids -axcascadelake,CORE-AVX2 -flto -fuse-ld=lld"'
+
 
     # Intermediate-level dependencies
     gcom4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,10 +6,10 @@
 # Build with:
 # - UM7 from dev-access-esm1.6 branch
 # - MOM5 from development branch
-# - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
+# - CICE5 from access-esm1.6 branch.
 spack:
   specs:
-    - access-esm1p6@latest
+    - access-esm1p6@latest cice=5
   packages:
     mom5:
       require:
@@ -17,11 +17,9 @@ spack:
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-    cice4:
+    cice5:
       require:
-        # '/qljzx7x'
-        # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - '@git.a0e238d50dfca346f171dc4273305b6a09e5d4a7=access-esm1.6'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
+        - '@git.6a861b3b6da03f50a3fae6c9417d6a2050b0f7f9=access-esm1.6'
         - '+access-gtracers'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O0"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,10 +30,10 @@ spack:
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
-        - 'cflags="-g -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'cxxflags="-g -O2 -march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g -O2 -march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
+        - 'cflags="-g3 -O2 -march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'cxxflags="-g3 -O2 -march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
+        - 'ldflags="-g3 -O2 -march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,12 +15,24 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
+        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+
+
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
+        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
 
     # Intermediate-level dependencies
     gcom4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -unroll"'
 
@@ -23,17 +23,17 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
         - 'cflags="-march=cascadelake -axsapphirerapids -fprotect-parens -unroll"'
         - 'cxxflags="-march=cascadelake -axsapphirerapids -fprotect-parens -unroll"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -qopt-zmm-usage=high -unroll -flto"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -qopt-zmm-usage=high -unroll  -vec-threshold0 -flto"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto -fuse-ld=lld"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll  -vec-threshold0 -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,10 +30,10 @@ spack:
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -qopt-zmm-usage=high -unroll  -vec-threshold0 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll  -vec-threshold0 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-march=sapphirerapids   -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto"'
+        - 'ldflags="-march=sapphirerapids  -mtune=sapphirerapids -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,10 +30,10 @@ spack:
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback -init=snan -init=array -init=huge"'
+        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -heap-arrays -assume nan_compares -assume ieee_compares -traceback -init=snan -init=array -init=huge "'
         - 'cflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
         - 'cxxflags="-g3 -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld -init=snan -init=array -init=huge"'
+        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld -heap-arrays -init=snan -init=array -init=huge"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,7 +21,7 @@ spack:
     cice4:
       require:
         # '/qljzx7x'
-        - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+        # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,9 +23,9 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
-        - 'cflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
-        - 'cxxflags="-march=sapphirerapids -axcascadelake,CORE-AVX2"'
+        - 'fflags="-march=cascadelake -axsapphirerapids,CORE-AVX2"'
+        - 'cflags="-march=cascadelake -axsapphirerapids,CORE-AVX2"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids,CORE-AVX2"'
 
     um7:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,6 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
-        # '/rjo4gre'
       - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -34,28 +33,24 @@ spack:
     # Intermediate-level dependencies
     gcom4:
       require:
-        # '/4ahbikn'
       - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
       - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
-        # '/6quqwyb'
       - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
       - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
-        # '/finlfac'
       - '@git.mom5-2025.05.000'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
       - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
-        # '/z2t66eo'
       - '@git.dev-2025.05.001'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -63,7 +58,6 @@ spack:
 
     access-mocsy:
       require:
-        # '/meqj55h'
       - '@git.2017.12.0'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -72,7 +66,6 @@ spack:
     # System-level packages
     openmpi:
       require:
-        # '/xid2pum'
       - '@4.1.5'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -80,7 +73,6 @@ spack:
 
     netcdf-c:
       require:
-        # '/dpqjhl3'
       - '@4.7.4'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -88,7 +80,6 @@ spack:
 
     netcdf-fortran:
       require:
-        # '/vqb6dyd'
       - '@4.5.2'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -96,7 +87,6 @@ spack:
 
     hdf5:
       require:
-        # '/v7qxufc'
       - '@1.10.11'
       - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
       - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,9 +23,9 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
 
     um7:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.6a861b3b6da03f50a3fae6c9417d6a2050b0f7f9=access-esm1.6'
+        - '@git.7f3317663cd7ade995476c4e0dc09d361ad3bd36=access-esm1.6'
         - '+access-gtracers'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.003c8a80bd223d2722b4aaca4174b3e3a21d87e6=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O2"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice5:
       require:
-        - '@git.a0e238d50dfca346f171dc4273305b6a09e5d4a7=access-esm1.6'
+        - '@git.ce970cdaa640889dab9454cbd7efaf9f628a2e8a=access-esm1.6'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
 
@@ -23,14 +23,14 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-march=cascadelake -axsapphirerapids -fprotect-parens"'
         - 'cxxflags="-march=cascadelake -axsapphirerapids -fprotect-parens"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge -flto"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto"'
         - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto -fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,24 +15,24 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
         - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto -fuse-ld=lld"'
 
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,9 +13,9 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.003c8a80bd223d2722b4aaca4174b3e3a21d87e6=access-esm1.6'
+        - '@git.88a8e566ac50ff8f34db78f99ff891385d48f213=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O1"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,20 +15,20 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:
       require:
         # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
         - '@git.ad219516fcbb5386739e3e07ab7fef6a54634034=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
@@ -36,32 +36,32 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
         - '@git.mom5-2025.04.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.04.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids"'
-        - 'cflags="-march=cascadelake -axsapphirerapids"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
@@ -23,52 +23,52 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -assume nan_compares -assume ieee_compares -traceback -init=snan -init=array -init=huge"'
         - 'cflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
         - 'cxxflags="-g3 -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld"'
+        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld -init=snan -init=array -init=huge"'
 
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-fms:
       require:
         - '@git.mom5-dev-2025.02.3'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.02.1'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,8 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
+        # - '@git.dev-2025.03.001=access-esm1.6'
+        - '@git.68ba5781d56d690669293ac7fdcc8a453fac58f0=access-esm1.6'
         - '+access-gtracers'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,105 +14,93 @@ spack:
     mom5:
       require:
         - '@git.ad1e41e2f7687a09e82addf5edbcca18fdd43ed5=access-esm1.6'
-        - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-          -traceback -fpe3"
-        - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-        - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice5:
       require:
         - '@git.a0e238d50dfca346f171dc4273305b6a09e5d4a7=access-esm1.6'
-        - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-          -traceback"
-        - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-        - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
         # '/rjo4gre'
       - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
         # '/4ahbikn'
       - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
         # '/6quqwyb'
       - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
         # '/finlfac'
       - '@git.mom5-2025.05.000'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
         # '/z2t66eo'
       - '@git.dev-2025.05.001'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
         # '/meqj55h'
       - '@git.2017.12.0'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
         # '/xid2pum'
       - '@4.1.5'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-c:
       require:
         # '/dpqjhl3'
       - '@4.7.4'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-fortran:
       require:
         # '/vqb6dyd'
       - '@4.5.2'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     hdf5:
       require:
         # '/v7qxufc'
       - '@1.10.11'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+      - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,9 +13,9 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.7f3317663cd7ade995476c4e0dc09d361ad3bd36=access-esm1.6'
+        - '@git.003c8a80bd223d2722b4aaca4174b3e3a21d87e6=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -assume dummy_aliases"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice5:
       require:
-        - '@git.ce970cdaa640889dab9454cbd7efaf9f628a2e8a=access-esm1.6'
+        - '@git.043d55005b7c83f3ae3de0f5846dc6cf17f0fbfd=access-esm1.6'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,123 +6,129 @@
 # Build with:
 # - UM7 from dev-access-esm1.6 branch
 # - MOM5 from development branch
-# - CICE5 from access-esm1.6 branch.
+# - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@latest cice=5
+  - access-esm1p6@latest
   packages:
     mom5:
       require:
         - '@git.ad1e41e2f7687a09e82addf5edbcca18fdd43ed5=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-    cice5:
+        - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+          -traceback"
+        - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+        - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+    cice4:
       require:
-        - '@git.a0e238d50dfca346f171dc4273305b6a09e5d4a7=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        # '/qljzx7x'
+        # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
+      - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
     um7:
       require:
         # '/rjo4gre'
-        - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     # Intermediate-level dependencies
     gcom4:
       require:
         # '/4ahbikn'
-        - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
     oasis3-mct:
       require:
         # '/6quqwyb'
-        - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
     access-fms:
       require:
         # '/finlfac'
-        - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@git.mom5-2025.05.000'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
     access-generic-tracers:
       require:
         # '/z2t66eo'
-        - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@git.dev-2025.05.001'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     access-mocsy:
       require:
         # '/meqj55h'
-        - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@git.2017.12.0'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     # System-level packages
     openmpi:
       require:
         # '/xid2pum'
-        - '@4.1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@4.1.5'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     netcdf-c:
       require:
         # '/dpqjhl3'
-        - '@4.7.4'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@4.7.4'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     netcdf-fortran:
       require:
         # '/vqb6dyd'
-        - '@4.5.2'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@4.5.2'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     hdf5:
       require:
         # '/v7qxufc'
-        - '@1.10.11'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+      - '@1.10.11'
+      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+        -traceback"
+      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
 
     gcc-runtime:
       require:
-        - '%gcc'
+      - '%gcc'
 
     glibc:
       require:
-        - '%gcc'
-        
-    zlib-ng:
-      require:
-        - '%gcc'
-
-    pkgconf:
-      require:
-        - '%gcc'
+      - '%gcc'
 
     # Preferences for all packages
     all:
       require:
-        - '%oneapi@2025.1.1'
-        - 'target=x86_64_v3'
+      - '%oneapi@2025.0.4'
+      - target=x86_64_v3
   view: true
   concretizer:
     unify: false
@@ -130,15 +136,15 @@ spack:
     default:
       tcl:
         include:
-          - access-esm1p6
-          - cice4
-          - um7
-          - mom5
+        - access-esm1p6
+        - cice4
+        - um7
+        - mom5
         projections:
           access-esm1p6: '{name}/latest'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           um7: '{name}/ad219516fcbb5386739e3e07ab7fef6a54634034-{hash:7}'
-          mom5: '{name}/dev-2025.03.001-{hash:7}'
+          mom5: '{name}/oneapi-floatingpoint-fix-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.7f3317663cd7ade995476c4e0dc09d361ad3bd36=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -assume dummy_aliases"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fma -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,8 +23,8 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
-        - 'cflags="g3 -xCORE-AVX2 -fprotect-parens -unroll"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll  -vec-threshold0"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens -unroll"'
 
     um7:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.88a8e566ac50ff8f34db78f99ff891385d48f213=access-esm1.6'
+        - '@git.ad1e41e2f7687a09e82addf5edbcca18fdd43ed5=access-esm1.6'
         - '+access-gtracers'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
@@ -23,52 +23,52 @@ spack:
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -heap-arrays -assume nan_compares -assume ieee_compares -traceback -init=snan -init=array -init=huge "'
+        - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -heap-arrays -assume nan_compares -assume ieee_compares -assume nominus0 -traceback"'
         - 'cflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
         - 'cxxflags="-g3 -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
-        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld -heap-arrays -init=snan -init=array -init=huge"'
+        - 'ldflags="-g3  -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -fuse-ld=lld -heap-arrays"'
 
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-fms:
       require:
         - '@git.mom5-dev-2025.02.3'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.02.1'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
@@ -76,28 +76,28 @@ spack:
     openmpi:
       require:
         - '@5.0.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-c:
       require:
         - '@4.9.2'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     netcdf-fortran:
       require:
         - '@4.6.1'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     hdf5:
       require:
         - '@1.14.3'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -assume nominus0 -fpe0 -traceback -check all"'
         - 'cflags="-g3 -xCORE-AVX2"'
         - 'cxxflags="-g3 -xCORE-AVX2"'
 
@@ -114,7 +114,7 @@ spack:
     all:
       require:
         - '%oneapi@2025.0.4'
-        - 'target=x86_64_v3'
+        # - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from access-esm1.6 branch.
 spack:
   specs:
-    - 'access-esm1p6 cice=5 um=access-esm1.6'
+    - 'access-esm1p6@latest cice=5 um=access-esm1.6'
   packages:
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-  - access-esm1p6@latest
+  - access-esm1p6@latest cice=5
   packages:
     mom5:
       require:
@@ -18,15 +18,13 @@ spack:
           -traceback"
         - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
         - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
-    cice4:
+    cice5:
       require:
-        # '/qljzx7x'
-        # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-      - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-      - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
-        -traceback"
-      - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
-      - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
+        - '@git.a0e238d50dfca346f171dc4273305b6a09e5d4a7=access-esm1.6'
+        - fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares
+          -traceback"
+        - cflags="-g3 -xCORE-AVX2 -fprotect-parens"
+        - cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"
     um7:
       require:
         # '/rjo4gre'
@@ -137,12 +135,12 @@ spack:
       tcl:
         include:
         - access-esm1p6
-        - cice4
+        - cice5
         - um7
         - mom5
         projections:
           access-esm1p6: '{name}/latest'
-          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          cice5: '{name}/a0e238d50dfca346f171dc4273305b6a09e5d4a7-{hash:7}'
           um7: '{name}/ad219516fcbb5386739e3e07ab7fef6a54634034-{hash:7}'
           mom5: '{name}/oneapi-floatingpoint-fix-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -fprotect-parens"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -fprotect-parens"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3  -fp-model=fast=1 -fimf-precision=high -fprotect-parens -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -unroll"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -fprotect-parens"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -fprotect-parens"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -unroll"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -fprotect-parens -unroll"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -fprotect-parens -unroll"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -init=snan -init=array -init=huge -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -fpe0 -traceback -check all -qopt-zmm-usage=high -unroll -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -fprotect-parens -qopt-zmm-usage=high -unroll -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -114,6 +114,10 @@ spack:
       require:
         - '%gcc'
 
+    pkgconf:
+      require:
+        - '%gcc'
+
     # Preferences for all packages
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,20 +15,20 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O0"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:
       require:
         # - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
         - '@git.ad219516fcbb5386739e3e07ab7fef6a54634034=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
@@ -36,32 +36,32 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
         - '@git.mom5-2025.04.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.04.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -check all,nouninit"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -115,7 +115,7 @@ spack:
     # Preferences for all packages
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%oneapi@2025.1.1'
         - 'target=x86_64_v3'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,25 +15,25 @@ spack:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
 
 
     cice4:
       require:
         - '@git.b51e3529bd78fd852760e348983e2334341f861d=access-esm1.5'
-        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high"'
-        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high"'
-        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high"'
+        - 'fflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'cflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
+        - 'cxxflags="-march=cascadelake -axsapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3"'
 
     um7:
       require:
         - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -qopt-zmm-usage=high -qopt-prefetch=3 -flto -fuse-ld=lld"'
 
 
     # Intermediate-level dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
 
     um7:
       require:
-        - '@git.e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd=access-esm1.6'
+        - '@git.ad219516fcbb5386739e3e07ab7fef6a54634034=access-esm1.6'
         - 'fflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto -align array64byte -heap-arrays -assume nan_compares -assume ieee_compares -assume nominus0 -traceback"'
         - 'cflags="-g3   -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
         - 'cxxflags="-g3 -O2 -xCORE-AVX2 -fprotect-parens -qopt-prefetch-loads-only -qopt-zmm-usage=high -vec-threshold0 -unroll -fno-omit-frame-pointer -flto"'
@@ -129,7 +129,7 @@ spack:
         projections:
           access-esm1p6: '{name}/latest'
           cice4: '{name}/b51e3529bd78fd852760e348983e2334341f861d-{hash:7}'
-          um7: '{name}/e31a07dfb4c57b5ac6d9277e6592f04b8e9357cd-{hash:7}'
+          um7: '{name}/ad219516fcbb5386739e3e07ab7fef6a54634034-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         - '@git.6a861b3b6da03f50a3fae6c9417d6a2050b0f7f9=access-esm1.6'
         - '+access-gtracers'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -O0"'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     cice4:


### PR DESCRIPTION
Test build with cice5 and oneapi

---
:rocket: The latest prerelease `access-esm1p6/pr97-13` at 07dcd033facdddc5a2028cad818e621013bdfdf4 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/97#issuecomment-3047480876 :rocket:












