### PR TITLE
Added the known working version for oneapi

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.05.002"
+    "spack-packages": "2025.07.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.05.002"
+    "spack-packages": "cice4-add-variant-ld"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.002"
+    "spack-packages": "2025.05.002"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "cice4-add-variant-ld"
+    "spack-packages": "2025.03.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,9 +27,10 @@ spack:
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     # Intermediate-level dependencies
     gcom4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
 
     cice4:
       require:
@@ -43,22 +43,22 @@ spack:
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -117,7 +117,7 @@ spack:
     all:
       require:
       - '%oneapi@2025.2.0'
-      - target=x86_64_v4
+      - target=x86_64_v3
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -135,7 +135,7 @@ spack:
           access-esm1p6: '{name}/latest'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
-          mom5: '{name}/b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4-{hash:7}'
+          mom5: '{name}/9f575d8532579a0f717002c571e68037e79c7396-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,84 +13,86 @@ spack:
   packages:
     mom5:
       require:
-        - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -no-ftz -no-daz"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
+        - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-flto -fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     # System-level packages
     openmpi:
       require:
         - '@4.1.5'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     netcdf-c:
       require:
         - '@4.7.4'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     netcdf-fortran:
       require:
         - '@4.5.2'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     hdf5:
       require:
         - '@1.10.11'
-        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
-        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
 
     gcc-runtime:
       require:
@@ -104,7 +106,7 @@ spack:
     all:
       require:
       - '%oneapi@2025.0.4'
-      - target=x86_64_v3
+      - target=x86_64_v4
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,9 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'direct_ldflags="-march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -82,7 +82,6 @@ spack:
     netcdf-c:
       require:
         - '@4.9.2'
-        - '+ipo'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,9 +21,10 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-flto -fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -68,7 +68,7 @@ spack:
     # System-level packages
     openmpi:
       require:
-        - '@4.1.5'
+        - '@5.0.8'
 
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,10 +14,10 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0 -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -flto -fuse-ld=lld"'
 
     cice4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,10 +38,10 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     oasis3-mct:
       require:
@@ -53,26 +53,26 @@ spack:
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -82,26 +82,26 @@ spack:
     netcdf-c:
       require:
         - '@4.9.2'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-flto -fuse-ld=lld"'
 
     netcdf-fortran:
       require:
         - '@4.6.1'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-flto -fuse-ld=lld"'
 
     hdf5:
       require:
         - '@1.14.3'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-fuse-ld=lld"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -70,7 +70,7 @@ spack:
 
     access-mocsy:
       require:
-        - '@git.2017.12.0=gtracers'
+        - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,10 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'linker=lld'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -46,7 +46,7 @@ spack:
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -82,18 +82,18 @@ spack:
     netcdf-c:
       require:
         - '@4.9.2'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     netcdf-fortran:
       require:
         - '@4.6.1'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     hdf5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -98,7 +98,7 @@ spack:
 
     hdf5:
       require:
-        - '@1.14.6'
+        - '@1.14.5'
         - '+ipo'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,21 +15,21 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -38,7 +38,7 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -46,14 +46,14 @@ spack:
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -61,7 +61,7 @@ spack:
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -69,7 +69,7 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -48,7 +48,7 @@ spack:
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
 
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
         - 'direct_ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.7ed9865cc55a631da5bdafa451bb4cae09569197=access-esm1.6' # This contains the !CDIR -> !DIR$ compiler directive fix
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -48,14 +48,15 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -69,7 +69,7 @@ spack:
 
     access-mocsy:
       require:
-        - '@git.2017.12.0'
+        - '@git.2017.12.0=gtracers'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,21 +15,21 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -38,7 +38,7 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -46,14 +46,14 @@ spack:
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -61,7 +61,7 @@ spack:
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -69,7 +69,7 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,21 +15,21 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -38,7 +38,7 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -46,14 +46,14 @@ spack:
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -61,7 +61,7 @@ spack:
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -69,7 +69,7 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,86 +15,97 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-fuse-ld=lld"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
+
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
+
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
 
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
 
     # System-level packages
     openmpi:
       require:
         - '@4.1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
 
     netcdf-c:
       require:
         - '@4.7.4'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
 
     netcdf-fortran:
       require:
         - '@4.5.2'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
 
     hdf5:
       require:
         - '@1.10.11'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'ldflags="-fuse-ld=lld"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -81,7 +81,8 @@ spack:
 
     netcdf-c:
       require:
-        - '@4.7.4'
+        - '@4.9.2'
+        - '+ipo'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
@@ -89,7 +90,7 @@ spack:
 
     netcdf-fortran:
       require:
-        - '@4.5.2'
+        - '@4.6.1'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
@@ -97,7 +98,8 @@ spack:
 
     hdf5:
       require:
-        - '@1.10.11'
+        - '@1.14.6'
+        - '+ipo'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
 
     oasis3-mct:
       require:
-        - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
+        - '@git.99d22674df8f304eb29c216e50d39ad4c0f24c27=access-esm1.5'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,21 +15,21 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -38,7 +38,7 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -46,14 +46,14 @@ spack:
     oasis3-mct:
       require:
         - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -61,7 +61,7 @@ spack:
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'
@@ -69,7 +69,7 @@ spack:
     access-mocsy:
       require:
         - '@git.2017.12.0'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -78,7 +78,7 @@ spack:
     # System-level packages
     openmpi:
       require:
-        - '@5.0.5'
+        - '@4.1.7'
 
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,10 +22,10 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'linker=lld'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'direct_ldflags="-march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -114,7 +114,7 @@ spack:
     # Preferences for all packages
     all:
       require:
-      - '%oneapi@2025.0.4'
+      - '%oneapi@2025.2.0'
       - target=x86_64_v4
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,67 +9,119 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.06.000
+    - access-esm1p6@latest
   packages:
     mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
+        - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -no-ftz -no-daz"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - '+access-gtracers'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
+    # Intermediate-level dependencies
     gcom4:
       require:
-        - '@git.2024.05.28=access-esm1.5'
+        - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-    openmpi:
-      require:
-        - '@4.1.5'
-    netcdf-c:
-      require:
-        - '@4.7.4'
-    netcdf-fortran:
-      require:
-        - '@4.5.2'
-    hdf5:
-      require:
-        - '@1.10.11'
+        - '@git.7036f26ece68c26083fec2fe96e3cb1faed7559d=access-esm1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-fms:
       require:
-        - '@git.mom5-2025.04.001'
+        - '@git.mom5-2025.05.000'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.04.001'
+        - '@git.dev-2025.05.001'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
     access-mocsy:
       require:
         - '@git.2017.12.0'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
+    # System-level packages
+    openmpi:
+      require:
+        - '@4.1.5'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
+    netcdf-c:
+      require:
+        - '@4.7.4'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
+    netcdf-fortran:
+      require:
+        - '@4.5.2'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
+    hdf5:
+      require:
+        - '@1.10.11'
+        - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+        - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
+
+    gcc-runtime:
+      require:
+      - '%gcc'
+
+    glibc:
+      require:
+      - '%gcc'
 
     # Preferences for all packages
     all:
       require:
-        - '%intel@19.0.3.199'
-        - 'target=x86_64_v4'
+      - '%oneapi@2025.0.4'
+      - target=x86_64_v3
   view: true
   concretizer:
-    unify: true
+    unify: false
   modules:
     default:
       tcl:
         include:
-          - access-esm1p6
-          - cice4
-          - um7
-          - mom5
+        - access-esm1p6
+        - cice4
+        - um7
+        - mom5
         projections:
-          access-esm1p6: '{name}/dev_2025.06.000'
+          access-esm1p6: '{name}/latest'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
-          mom5: '{name}/dev-2025.03.001-{hash:7}'
+          um7: '{name}/1ea43190add8627fb317906d257f278763b55125-{hash:7}'
+          mom5: '{name}/b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,10 +38,10 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     oasis3-mct:
       require:
@@ -49,7 +49,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -48,7 +48,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-fms:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,10 +15,10 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -78,7 +78,7 @@ spack:
     # System-level packages
     openmpi:
       require:
-        - '@4.1.7'
+        - '@5.0.5'
 
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,6 @@ spack:
   packages:
     mom5:
       require:
-        ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
@@ -45,7 +44,6 @@ spack:
 
     oasis3-mct:
       require:
-#        - '@git.99d22674df8f304eb29c216e50d39ad4c0f24c27=access-esm1.5'
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
@@ -84,26 +82,14 @@ spack:
     netcdf-c:
       require:
         - '@4.9.2'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-flto -fuse-ld=lld"'
 
     netcdf-fortran:
       require:
         - '@4.6.1'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-flto -fuse-ld=lld"'
 
     hdf5:
       require:
         - '@1.14.3'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-fuse-ld=lld"'
 
     gcc-runtime:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,10 +29,10 @@ spack:
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - 'ldflags="-flto -fuse-ld=lld"'
 
     # Intermediate-level dependencies
     gcom4:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,10 +14,10 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     cice4:
       require:
@@ -46,26 +46,26 @@ spack:
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
+        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-mocsy:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,26 +20,26 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'direct_ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids"'
+        - 'direct_ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # Intermediate-level dependencies
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     oasis3-mct:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
     um7:
       require:
-        - '@git.1ea43190add8627fb317906d257f278763b55125=access-esm1.6'
+        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
@@ -119,7 +119,7 @@ spack:
         projections:
           access-esm1p6: '{name}/latest'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/1ea43190add8627fb317906d257f278763b55125-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
         ## - '@git.b0c3e51f6959c90d2a8d034fc4c54846f36ddfd4=access-esm1.6' # This contains all the FP fixes with NOVECTOR
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'ldflags="-flto -fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,8 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3 -flto -fuse-ld=lld"'
 
     cice4:
       require:
@@ -44,21 +45,25 @@ spack:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3 -flto -fuse-ld=lld"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3 -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3 -flto -fuse-ld=lld"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3 -flto -fuse-ld=lld"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -56,7 +56,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:
@@ -64,7 +64,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-mocsy:
       require:
@@ -72,7 +72,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -49,7 +49,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,9 +22,10 @@ spack:
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        - 'direct_ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
 
     cice4:
       require:
@@ -43,22 +43,22 @@ spack:
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,10 +14,7 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
 
     cice4:
       require:
@@ -46,34 +43,22 @@ spack:
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
-        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
 
     # System-level packages
     openmpi:
@@ -104,7 +89,7 @@ spack:
     all:
       require:
       - '%oneapi@2025.2.0'
-      - target=x86_64_v3
+      - target=x86_64_v4
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,11 +77,7 @@ spack:
     # System-level packages
     openmpi:
       require:
-        - '@4.1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-fuse-ld=lld"'
+        - '@5.0.5'
 
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -48,17 +48,17 @@ spack:
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,6 @@ spack:
         - 'fflags="-g3 -xCORE-AVX2 -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -no-ftz -no-daz"'
         - 'cflags="-g3 -xCORE-AVX2 -fprotect-parens"'
         - 'cxxflags="-g3 -xCORE-AVX2 -fprotect-parens"'
-        - '+access-gtracers'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
 
     cice4:
       require:
@@ -43,22 +43,22 @@ spack:
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -99,7 +99,6 @@ spack:
     hdf5:
       require:
         - '@1.14.3'
-        - '+ipo'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     cice4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0 -flto -fuse-ld=lld"'
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
@@ -32,7 +32,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # Intermediate-level dependencies
     gcom4:
@@ -41,7 +41,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     oasis3-mct:
       require:
@@ -49,14 +49,14 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:
@@ -64,7 +64,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-mocsy:
       require:
@@ -72,7 +72,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -traceback"'
 
     cice4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,10 +38,10 @@ spack:
     gcom4:
       require:
         - '@git.0f17657a3b21cda9c0f3c403d99667e436062e38=access-esm1.5'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-flto -fuse-ld=lld"'
+        - 'ldflags="-fuse-ld=lld"'
 
     oasis3-mct:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -70,10 +70,10 @@ spack:
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,8 @@ spack:
 
     oasis3-mct:
       require:
-        - '@git.99d22674df8f304eb29c216e50d39ad4c0f24c27=access-esm1.5'
+#        - '@git.99d22674df8f304eb29c216e50d39ad4c0f24c27=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -98,7 +98,7 @@ spack:
 
     hdf5:
       require:
-        - '@1.14.5'
+        - '@1.14.3'
         - '+ipo'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback "'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -32,7 +32,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # Intermediate-level dependencies
     gcom4:
@@ -41,7 +41,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     oasis3-mct:
       require:
@@ -49,14 +49,14 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -O2 -qopt-prefetch -flto -fuse-ld=lld"'
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:
@@ -64,7 +64,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-mocsy:
       require:
@@ -72,7 +72,7 @@ spack:
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
         - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
         - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
 
     cice4:
       require:
@@ -43,22 +43,22 @@ spack:
     oasis3-mct:
       require:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
 
     access-fms:
       require:
         - '@git.mom5-2025.05.000'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
 
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
 
     access-mocsy:
       require:
         - '@git.1e4bc055519a6446232dcff803e7b80e56c49424=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -qopt-zmm-usage=high -vec-threshold0 -O3"'
 
     # System-level packages
     openmpi:

--- a/spack.yaml
+++ b/spack.yaml
@@ -54,9 +54,9 @@ spack:
       require:
         - '@git.mom5-2025.05.000'
         - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -fuse-ld=lld"'
+        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
+        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -O2 -flto"'
+        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -traceback -qopt-zmm-usage=high -O2 -qopt-prefetch -flto -fuse-ld=lld"'
 
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,10 +14,11 @@ spack:
     mom5:
       require:
         - '@git.9f575d8532579a0f717002c571e68037e79c7396=access-esm1.6' # This is the last commit before I branched off the FP fixes. From Dougie with the CMAKE fixes
-        - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0"'
-        - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
-        - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0 -flto -fuse-ld=lld"'
+        # - 'fflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0"'
+        # - 'cflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'cxxflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens"'
+        # - 'ldflags="-g3 -march=cascadelake -mtune=sapphirerapids -fprotect-parens -assume nan_compares -assume ieee_compares -traceback -fpe3 -qopt-zmm-usage=high -qvec-threshold0 -O2 -qopt-prefetch -flto -unroll=0 -flto -fuse-ld=lld"'
+
     cice4:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -78,7 +78,7 @@ spack:
     # System-level packages
     openmpi:
       require:
-        - '@5.0.5'
+        - '@4.1.5'
 
     netcdf-c:
       require:


### PR DESCRIPTION
**Do not merge**

This is for optimising the working ~~AVX2 build~~ CASCADELAKE architecture (and tuning for SAPPHIRERAPIDS). 


*Edit*: 19th June, 2025 to add the following - 

# Update + optimisation checklist:

## Update dependencies:
- [x] Update to `openmpi/5.0.5`
- [x] Update to `netcdf/4.9.2`
- [x] Update to `hdf5/1.14.3`

Done in [`pr98-14`](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2987783261). 10-day experiment runtime goes from 3m43s (`pr98-8`) to 3m56s (`pr98-14`).


## Compiler flags:
- [x] Make sure that everything has `-O2`
- [ ] `-flto` + `-flto -fuse-ld=lld`
- [x] `-qopt-zmm-usage=high`
- [x] `-qopt-zmm-usage=high -qvec-threshold0`
- [x] `-qopt-prefetch`
- [ ] Check whether the streaming loads and stores options make any difference. 

## Partitioning and MPI params
- [ ] Check whether using a lower number of nodes makes a runtime + SUs difference
- [ ] Check whether a different partitioning scheme works better (since MOM5 scales better than UM7)
- [ ] Check whether tuning `mca` params helps. Specifically, whether distributing UM7 across all the compute nodes (to maximise memory bandwidth) and then filling in mom5 + cice4/5 among the rest of the cores helps
- [ ] Check whether oversubscribing the core count (but reducing the overall nodes) helps. (Need to find out whether payu allows this)

## Stretch:
- [ ] Use `-mkl` (need to figure out how to link in mkl)
- [ ] Replace `oasis3-mct` with `cerfacs/oasis3-mct`
- [ ] Use shared libraries instead of static (big stretch)



# Summary of runtimes and SUs:

<!--

Builds are cumulative, i.e., later builds include all flags from the previous build + one extra bit (which is noted). This is for a PI-config 1-year run; ccean and atmosphere outputs are bitwise identical. The table is sorted on walltime:

| Walltime     | SUs         | Directory                                
|--------------|-------------|------------------------------------------
| 01:35:02     | 1317.80     | access-esm1.6-PI-Jun19-perf-opt-pr98-8 (base build with default dependencies, `-march=cascadelake -mtune=sapphirerapids`)
| 01:38:57     | 1372.11     | access-esm1.6-PI-Jun19-perf-opt-pr98-18 (Added `-qopt-prefetch`)
| 01:39:41     | 1382.28     | access-esm1.6-PI-Jun19-perf-opt-pr98-17 (Added `-O2`)
| 01:40:05     | 1387.82     | access-esm1.6-PI-Jun19-perf-opt-pr98-15 (Added `-qopt-zmm-usage=high`)
| 01:40:40     | 1395.91     | access-esm1.6-PI-Jun19-perf-opt-pr98-16 (Added `-qvec-threshold0`)
| 01:42:04     | 1415.32     | access-esm1.6-PI-Jun19-perf-opt-pr98-14 (next build from base, + `ompi/5.0.5, netcdf-c/4.9.2, netcdf-fortran/4.6.1, hdf5/1.14.3`)
For reference, the classic `ifort` run completed in 1h13min - see comment [here](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2989714496).
-->


Top 10 best performing (as measured by simulated years/wallclock-day) and the released config :

| yrs/Wallday | Walltime (mins) |   SUs  | CPUs | yrs/core/Wday | Directory                                
|-------------|-----------------|--------|------|---------------|------------------------------------------
|        22.0 |            65.3 | 1132.7 |  520 |      4.24e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-spack-built-um7-with-flags-and-mom5-both-oneapi2025-2-0-atm-layout-16x16-ocean-layout-18x14-cice4-12
|        21.8 |            66.1 | 1145.4 |  520 |      4.19e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505-atm-layout-16x16-ocean-layout-18x14-cice4-12
|        21.6 |            66.7 | 1155.6 |  520 |      4.15e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x16-ocean-layout-18x14-cice4-12-mom-with-oneapi2025-2-0
|        21.0 |            68.5 | 1187.6 |  520 |      4.04e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-layout-16x17-ocean-layout-15x15-cice4-12
|        20.4 |            70.7 | 1224.6 |  520 |      3.92e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505-atm-layout-16x17-ocean-layout-15x15-cice4-12
|        20.0 |            71.8 | 1245.4 |  520 |      3.85e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-layout-16x17-ocean-layout-18x13-cice4-12
|        20.0 |            72.0 | 1248.9 |  520 |      3.84e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-layout-16x16-ocean-layout-18x14-cice4-12
|        19.9 |            72.2 | 1001.4 |  416 |      4.79e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-mpi-yield-when-idle-true
|        19.9 |            72.5 | 1256.4 |  520 |      3.82e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x16-ocean-layout-16x15-cice4-12-mom-with-oneapi2025-2-0
|        19.8 |            72.8 | 1008.8 |  416 |      4.76e-02 | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415 (**Performance parity with classic Intel, oneAPI@2025.2.0 + openmpi/4.1.5**)
|        19.7 |            73.0 | 1012.3 |  416 |      4.74e-02 | access-esm1.6-PI-Jun20-released-config (**Classic Intel released config**)



## Further details on the runs

Printing runtime and imbalance results (all times are in mins):

```
Col 1: yrs/Wday : Simulated years/wallclock-days
WTime (imbal.) : Walltime in mins - lower is better. Imbalance = sum(GETO2A_COMM, oasis_recv, oasis_recv1) - lower is better
SUs: Number of SUs used - lower is better
CPUs: Number of CPUs requested - lower is better
yrs: Number of simulated years - higher is better
yrs/core/Wday: Number of simulated years/core/Wallclock-day - a measure of computational efficiency - higher is better
Atm Wt(O2A, Wt-O2A): Atmosphere wallclock time (parsed from `atm.fort6.pe0`). O2A = first `GETO2A_COMM` match in the `atm.fort6.pe0` file. Wt-O2A = the difference between Wt and O2A (measures what Wt could have been if O2A was 0)
Ocn Wt (recvs, Wt - recvs): Ocean wallclock time (parsed from `logfile.00000.out`. recvs = sum(`oasis_recv`, `oasis_recv1`) parsed from the logfile. Wt - recvs = similar to atmosphere, best case measure of ocean walltime. 
```

Finished processing 74 directories!
Printing runtime and imbalance results (all times are in mins):
| yrs/Wday | WTime (imbal.) |   SUs  |  CPUs | yrs | yrs/core/Wday | Atm Wt(O2A, Wt-O2A) | Ocn Wt (recvs, Wt - recvs) | Directory                                
|----------|----------------|--------|-------|-----|---------------|---------------------|----------------------------|------------------------------------------
|     22.0 |   65.3 (11.9%) | 1132.7 |   520 | 1.0 |       4.2e-02 |   63.2 ( 3.3,   60) |          64.3 ( 4.5,   60) | access-esm1.6-PI-Jun19-perf-opt-pr98-spack-built-um7-with-flags-and-mom5-both-oneapi2025-2-0-atm-layout-16x16-ocean-layout-18x14-cice4-12 
|     21.8 |   66.1 (11.3%) | 1145.4 |   520 | 1.0 |       4.2e-02 |   63.8 ( 3.3,   60) |          64.9 ( 4.1,   61) | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505-atm-layout-16x16-ocean-layout-18x14-cice4-12 
|     21.6 |   66.7 (14.3%) | 1155.6 |   520 | 1.0 |       4.2e-02 |   64.3 ( 3.3,   61) |          65.6 ( 6.2,   59) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x16-ocean-layout-18x14-cice4-12-mom-with-oneapi2025-2-0 
|     21.0 |   68.5 (15.7%) | 1187.6 |   520 | 1.0 |       4.0e-02 |   66.1 ( 3.4,   63) |          67.3 ( 7.3,   60) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-layout-16x17-ocean-layout-15x15-cice4-12 
|     20.4 |   70.7 (16.8%) | 1224.6 |   520 | 1.0 |       3.9e-02 |   68.4 ( 8.3,   60) |          69.5 ( 3.5,   66) | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505-atm-layout-16x17-ocean-layout-15x15-cice4-12 
|     20.0 |   71.8 (20.5%) | 1245.4 |   520 | 1.0 |       3.9e-02 |   69.6 ( 3.5,   66) |          70.7 (11.3,   59) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-layout-16x17-ocean-layout-18x13-cice4-12 
|     20.0 |   72.0 (25.3%) | 1248.9 |   520 | 1.0 |       3.8e-02 |   69.7 ( 3.4,   66) |          70.9 (14.8,   56) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-layout-16x16-ocean-layout-18x14-cice4-12 
|     19.9 |   72.2 ( 8.9%) | 1001.4 |   416 | 1.0 |       4.8e-02 |   69.6 ( 4.4,   65) |          70.7 ( 2.0,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-mpi-yield-when-idle-true 
|     19.9 |   72.5 (17.7%) | 1256.4 |   520 | 1.0 |       3.8e-02 |   70.3 (10.2,   60) |          71.4 ( 2.6,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x16-ocean-layout-16x15-cice4-12-mom-with-oneapi2025-2-0 
|     19.8 |   72.8 ( 9.7%) | 1008.8 |   416 | 1.0 |       4.8e-02 |   70.5 ( 3.7,   67) |          71.7 ( 3.3,   68) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415 
|     19.7 |   73.0 ( 9.7%) | 1012.3 |   416 | 1.0 |       4.7e-02 |   70.6 ( 3.9,   67) |          72.0 ( 3.2,   69) | access-esm1.6-PI-Jun20-released-config 
|     19.7 |   73.1 ( 9.6%) | 1013.9 |   416 | 1.0 |       4.7e-02 |   70.7 ( 3.7,   67) |          72.1 ( 3.3,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-62-with-oneapi2025-2-0-ompi415-flto-for-all 
|     19.6 |   73.3 (11.0%) | 1271.1 |   520 | 1.0 |       3.8e-02 |   71.0 ( 3.3,   68) |          72.1 ( 4.8,   67) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x13-ocean-layout-20x15-cice4-12 
|     19.6 |   73.5 ( 8.7%) | 1019.4 |   416 | 1.0 |       4.7e-02 |   71.2 ( 4.1,   67) |          72.5 ( 2.2,   70) | access-esm1.6-PI-Jun19-perf-opt-pr98-59-with-oneapi2025-2-0-ompi415-march=ccl-mtune=spr-zmm-high-vecthreshold0-for-mom5-and-imm 
|     19.6 |   73.5 ( 9.6%) | 1019.9 |   416 | 1.0 |       4.7e-02 |   71.0 ( 3.6,   67) |          72.2 ( 3.4,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-56-with-oneapi2025-2-0-ompi415-removed-ieee_nan_compares_mom5_fms_mocsy_gtracers_flags 
|     19.6 |   73.6 ( 9.1%) | 1275.4 |   520 | 1.0 |       3.8e-02 |   71.3 ( 3.5,   68) |          72.4 ( 3.3,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-layout-16x13-ocean-layout-20x15-cice4-12 
|     19.4 |   74.1 ( 9.5%) | 1028.0 |   416 | 1.0 |       4.7e-02 |   71.7 ( 4.0,   68) |          73.1 ( 3.0,   70) | access-esm1.6-PI-Jun19-perf-opt-pr98-58-with-oneapi2025-2-0-ompi415-march=ccl-mtune=spr-unroll-for-mom5-and-imm 
|     19.4 |   74.2 (10.1%) | 1028.2 |   416 | 1.0 |       4.7e-02 |   71.6 ( 3.5,   68) |          72.8 ( 3.9,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-57-with-oneapi2025-2-0-ompi415-march=ccl-mtune=spr-for-mom5-and-imm-dependencies 
|     19.4 |   74.4 (15.0%) | 1289.3 |   520 | 1.0 |       3.7e-02 |   71.8 ( 3.5,   68) |          73.0 ( 7.6,   65) | access-esm1.6-PI-Jun19-perf-opt-pr98-8-atm-layout-16x13-ocean-layout-20x15-cice4-12 
|     19.3 |   74.5 ( 9.5%) | 1033.5 |   416 | 1.0 |       4.6e-02 |   71.6 ( 3.9,   68) |          73.1 ( 3.1,   70) | access-esm1.6-PI-Jun19-perf-opt-pr98-60-with-oneapi2025-2-0-ompi415-march=ccl-mtune=spr-zmm-high-vecthreshold0-O3-for-mom5-and-imm 
|     19.2 |   74.8 (35.3%) | 1296.8 |   520 | 1.0 |       3.7e-02 |   72.6 ( 3.7,   69) |          73.7 (22.8,   51) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x13-ocean-layout-20x15-cice4-12-mom-with-oneapi2025-2-0 
|     19.2 |   75.0 (11.8%) | 1040.7 |   416 | 1.0 |       4.6e-02 |   72.9 ( 6.1,   67) |          74.0 ( 2.7,   71) | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505 
|     19.1 |   75.2 (11.3%) | 1043.2 |   416 | 1.0 |       4.6e-02 |   72.9 ( 3.5,   69) |          74.1 ( 5.0,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-61-with-oneapi2025-2-0-ompi415-march=ccl-mtune=spr-zmm-high-vecthreshold0-O3-flto-for-mom5-and-imm 
|     19.1 |   75.3 (13.0%) | 1304.6 |   520 | 1.0 |       3.7e-02 |   73.1 ( 5.0,   68) |          74.1 ( 4.8,   69) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-16x13-ocean-layout-15x20-cice4-12 
|     19.0 |   75.9 (10.5%) | 1052.0 |   416 | 1.0 |       4.6e-02 |   73.6 ( 5.3,   68) |          74.7 ( 2.7,   72) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-mom5-from-spack-oneapi2025-2-0 
|     19.0 |   75.9 (13.2%) | 1052.2 |   416 | 1.0 |       4.6e-02 |   73.7 ( 7.2,   67) |          74.8 ( 2.8,   72) | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505-map-per-node-ppr-104 
|     18.8 |   76.5 (13.7%) | 1061.5 |   416 | 1.0 |       4.5e-02 |   74.4 ( 7.6,   67) |          75.5 ( 2.8,   73) | access-esm1.6-PI-Jun19-perf-opt-pr98-spack-built-um7-with-flags-and-mom5-both-oneapi2025-2-0 
|     18.8 |   76.6 (13.5%) | 1062.2 |   416 | 1.0 |       4.5e-02 |   74.4 ( 6.3,   68) |          75.5 ( 4.0,   71) | access-esm1.6-PI-Jun19-perf-opt-pr98-44-um7-and-mom5-from-spack-oneapi2025-2-0 
|     18.7 |   76.9 (16.8%) | 1066.8 |   416 | 1.0 |       4.5e-02 |   74.7 ( 3.3,   71) |          75.8 ( 9.6,   66) | access-esm1.6-PI-Jun19-perf-opt-pr98-spack-built-um7-with-flags-and-mom5-both-oneapi2025-2-0-atm-layout-14x13-ocean-layout-17x13-cice4-12 
|     18.3 |   78.6 (10.7%) | 1089.5 |   416 | 1.0 |       4.4e-02 |   76.3 ( 5.5,   71) |          77.5 ( 2.9,   75) | access-esm1.6-PI-Jun19-perf-opt-pr98-50-with-oneapi2025-2-0-ompi505-mpi-yield-when-idle-false 
|     18.2 |   79.2 (13.2%) | 1097.5 |   416 | 1.0 |       4.4e-02 |   76.9 ( 7.7,   69) |          78.1 ( 2.7,   75) | access-esm1.6-PI-Jun19-perf-opt-pr98-spack-built-um7-with-flags-and-mom5-both-oneapi2025-2-0-atm-layout-14x14-ocean-layout-16x13-cice4-12 
|     17.5 |   82.5 (13.3%) | 1143.5 |   416 | 1.0 |       4.2e-02 |   79.6 ( 7.4,   72) |          81.0 ( 3.6,   77) | access-esm1.6-PI-Jun19-perf-opt-pr98-49-with-oneapi2025-2-0-ompi417 
|     16.0 |   89.8 (23.7%) | 1245.5 |   416 | 1.0 |       3.9e-02 |   87.2 (19.0,   68) |          88.5 ( 2.3,   86) | access-esm1.6-PI-Jun19-perf-opt-pr98-53-with-oneapi2025-2-0-ompi415-removed-ieee_nan_compares_mom5_flags 
|     15.8 |   91.2 (12.3%) | 1264.2 |   416 | 1.0 |       3.8e-02 |   88.9 ( 8.6,   80) |          90.0 ( 2.7,   87) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-layout-12x13-ocean-layout-19x13-cice4-12 
|     15.8 |   91.3 (13.0%) |  949.7 |   312 | 1.0 |       5.1e-02 |   89.2 ( 3.2,   86) |          90.3 ( 8.7,   82) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-12x12-layout-ocean-13x12-layout-cice-12-mpi-yield-when-idle-true 
|     15.7 |   91.8 ( 8.9%) |  954.9 |   312 | 1.0 |       5.0e-02 |   89.6 ( 5.7,   84) |          90.8 ( 2.5,   88) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-12x12-layout-ocean-13x12-layout-cice-12-both-um-and-mom5-oneapi-2025.2.0 
|     15.6 |   92.5 (13.2%) | 1283.1 |   416 | 1.0 |       3.7e-02 |   90.3 (10.0,   80) |          91.4 ( 2.3,   89) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-12x13-ocean-layout-16x15-cice4-12 
|     15.5 |   92.7 (12.9%) |  963.6 |   312 | 1.0 |       5.0e-02 |   90.3 ( 3.7,   87) |          91.6 ( 8.2,   83) | access-esm1.6-PI-Jun20-released-config-atm-12x12-layout-ocean-13x12-layout-cice-12 
|     15.5 |   92.8 (13.7%) | 1286.1 |   416 | 1.0 |       3.7e-02 |   90.6 ( 9.9,   81) |          91.7 ( 2.8,   89) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-12x13-ocean-layout-19x13-cice4-12 
|     15.3 |   93.8 (13.2%) |  975.9 |   312 | 1.0 |       4.9e-02 |   91.4 ( 3.6,   88) |          92.6 ( 8.8,   84) | access-esm1.6-PI-Jun19-perf-opt-pr98-51-with-oneapi2025-2-0-ompi415-atm-12x12-layout-ocean-13x12-layout-cice-12 
|     15.2 |   95.0 ( 9.4%) | 1316.9 |   416 | 1.0 |       3.6e-02 |   90.5 ( 6.4,   84) |          91.7 ( 2.6,   89) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-layout-12x12-ocean-layout-16x16-cice4-12 
|     15.2 |   95.0 (27.7%) | 1317.8 |   416 | 1.0 |       3.6e-02 |   92.8 (24.3,   69) |          94.0 ( 2.1,   92) | access-esm1.6-PI-Jun19-perf-opt-pr98-8 
|     15.0 |   96.2 (17.3%) | 1334.0 |   416 | 1.0 |       3.6e-02 |   94.1 (14.4,   80) |          95.1 ( 2.2,   93) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-layout-12x13-ocean-layout-16x15-cice4-12 
|     14.9 |   96.7 (16.3%) | 1006.0 |   312 | 1.0 |       4.8e-02 |   93.5 ( 3.3,   90) |          94.7 (12.5,   82) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-10x13-layout-ocean-13x13-layout-cice-12-both-um-and-mom5-oneapi-2025.2.0 
|     14.7 |   98.1 (19.5%) | 1020.1 |   312 | 1.0 |       4.7e-02 |   95.6 (17.2,   78) |          96.9 ( 1.9,   95) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-12x13-layout-ocean-12x12-layout-cice-12-both-um-and-mom5-oneapi-2025.2.0 
|     14.6 |   99.0 (31.6%) | 1372.1 |   416 | 1.0 |       3.5e-02 |   96.7 (28.5,   68) |          97.9 ( 2.7,   95) | access-esm1.6-PI-Jun19-perf-opt-pr98-18 
|     14.5 |   99.0 (32.0%) | 1373.0 |   416 | 1.0 |       3.5e-02 |   96.7 (28.7,   68) |          97.8 ( 3.0,   95) | access-esm1.6-PI-Jun19-perf-opt-pr98-19 
|     14.5 |   99.2 (31.9%) | 1375.3 |   416 | 1.0 |       3.5e-02 |   96.6 (28.9,   68) |          98.0 ( 2.7,   95) | access-esm1.6-PI-Jun19-perf-opt-pr98-20 
|     14.4 |   99.7 (32.8%) | 1382.3 |   416 | 1.0 |       3.5e-02 |   97.3 (30.1,   67) |          98.4 ( 2.6,   96) | access-esm1.6-PI-Jun19-perf-opt-pr98-17 
|     14.4 |  100.1 (32.8%) | 1387.8 |   416 | 1.0 |       3.5e-02 |   97.9 (30.0,   68) |          99.0 ( 2.8,   96) | access-esm1.6-PI-Jun19-perf-opt-pr98-15 
|     14.3 |  100.7 (34.7%) | 1395.9 |   416 | 1.0 |       3.4e-02 |   98.2 (32.2,   66) |          99.3 ( 2.7,   97) | access-esm1.6-PI-Jun19-perf-opt-pr98-16 
|     14.3 |  100.7 (32.9%) | 1395.9 |   416 | 1.0 |       3.4e-02 |   98.5 (30.5,   68) |          99.6 ( 2.7,   97) | access-esm1.6-PI-Jun19-perf-opt-pr98-23 
|     14.3 |  100.7 (32.9%) | 1396.1 |   416 | 1.0 |       3.4e-02 |   98.4 (30.4,   68) |          99.6 ( 2.8,   97) | access-esm1.6-PI-Jun19-perf-opt-pr98-22 
|     14.3 |  100.7 (33.4%) | 1396.6 |   416 | 1.0 |       3.4e-02 |   98.5 (31.1,   67) |          99.5 ( 2.5,   97) | access-esm1.6-PI-Jun19-perf-opt-pr98-25 
|     14.2 |  101.4 (33.1%) | 1405.8 |   416 | 1.0 |       3.4e-02 |   99.2 (31.1,   68) |         100.3 ( 2.5,   98) | access-esm1.6-PI-Jun19-perf-opt-pr98-29 
|     14.2 |  101.6 (34.1%) | 1409.1 |   416 | 1.0 |       3.4e-02 |   99.4 (32.1,   67) |         100.5 ( 2.6,   98) | access-esm1.6-PI-Jun19-perf-opt-pr98-24 
|     14.1 |  102.1 (33.5%) | 1415.3 |   416 | 1.0 |       3.4e-02 |   99.9 (31.3,   69) |         101.0 ( 2.9,   98) | access-esm1.6-PI-Jun19-perf-opt-pr98-14 
|     13.3 |  108.5 (12.8%) | 1128.4 |   312 | 1.0 |       4.3e-02 |  106.4 ( 3.1,  103) |         107.5 (10.9,   97) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-8x13-layout-ocean-14x14-layout-cice-12 
|     13.3 |  108.5 (15.4%) | 1128.6 |   312 | 1.0 |       4.3e-02 |  106.1 ( 3.2,  103) |         107.2 (13.5,   94) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-8x13-layout-ocean-14x14-layout-cice-12-mca-scatter-all-three-components 
|     13.2 |  109.0 (34.8%) | 1511.9 |   416 | 1.0 |       3.2e-02 |  106.8 ( 3.1,  104) |         107.9 (34.9,   73) | access-esm1.6-PI-Jun19-perf-opt-pr98-29-atm-layout-10x11-ocean-layout-17x17-cice4-12 
|     13.2 |  109.2 (36.4%) | 1513.5 |   416 | 1.0 |       3.2e-02 |  107.0 ( 3.0,  104) |         108.1 (36.8,   71) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-8x13-ocean-layout-15x20-cice4-12 
|     13.2 |  109.2 (14.1%) | 1135.8 |   312 | 1.0 |       4.2e-02 |  107.1 ( 3.1,  104) |         108.2 (12.3,   96) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-8x13-layout-ocean-14x14-layout-cice-12 
|     13.2 |  109.4 (13.5%) | 1137.4 |   312 | 1.0 |       4.2e-02 |  107.0 ( 3.2,  104) |         108.3 (11.6,   97) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-8x13-layout-ocean-14x14-layout-cice-12-mca-scatter-all-three-components-not-as-exe-prefix-in-mpirun 
|     13.1 |  109.5 (40.4%) | 1518.6 |   416 | 1.0 |       3.2e-02 |  107.2 ( 3.0,  104) |         108.2 (41.2,   67) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-8x13-ocean-layout-20x15-cice4-12 
|     12.9 |  111.7 (40.4%) | 1161.3 |   312 | 1.0 |       4.1e-02 |  109.3 ( 4.0,  105) |         110.6 (41.1,   69) | access-esm1.6-PI-Jun20-released-config-atm-8x13-layout-ocean-14x14-layout-cice-12 
|     12.9 |  111.7 (20.4%) | 1549.4 |   416 | 1.0 |       3.1e-02 |  109.5 ( 3.2,  106) |         110.6 (19.6,   91) | access-esm1.6-PI-Jun19-perf-opt-pr98-18-atm-layout-12x13-ocean-layout-16x15-cice4-12-atm-npernode-39-ocean-npernode-60-cice4-npernode-3 
|     11.1 |  129.5 (46.8%) | 1796.2 |   416 | 1.0 |       2.7e-02 |  127.1 (58.2,   69) |         128.4 ( 2.3,  126) | access-esm1.6-PI-Jun19-perf-opt-pr98-52-with-oneapi2025-2-0-ompi415-mom5-and-dependencies-with-fflags 
|     10.7 |  134.4 (50.9%) | 1863.5 |   416 | 1.0 |       2.6e-02 |  132.0 (66.2,   66) |         133.4 ( 2.3,  131) | access-esm1.6-PI-Jun19-perf-opt-pr98-44-with-oneapi2025-2-0-map-by-numa-rank-by-fill 
|     10.7 |  134.8 (50.2%) | 1869.2 |   416 | 1.0 |       2.6e-02 |  132.2 (64.9,   67) |         133.3 ( 2.7,  131) | access-esm1.6-PI-Jun19-perf-opt-pr98-46-with-oneapi2025-2-0 
|     10.6 |  136.4 (51.9%) | 1891.9 |   416 | 1.0 |       2.5e-02 |  133.9 (68.0,   66) |         135.4 ( 2.8,  133) | access-esm1.6-PI-Jun19-perf-opt-pr98-44-with-oneapi2025-2-0 



---
:rocket: The latest prerelease `access-esm1p6/pr98-4` at 50b8093ffe07ceec5172c2b57cc736d3e4210b84 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2982591648 :rocket:






---
:rocket: The latest prerelease `access-esm1p6/pr98-14` at a173f7b89da6a6dcb0c18d340eb28faf772a6c18 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2987783261 :rocket:











---
:rocket: The latest prerelease `access-esm1p6/pr98-18` at 7a599627c43e5e1a59f3747f06581ed27af5cce7 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2989206120 :rocket:





---
:rocket: The latest prerelease `access-esm1p6/pr98-22` at e8b9cd88daadc5502230a2ec42ded65f8055b5e8 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2989995817 :rocket:





---
:rocket: The latest prerelease `access-esm1p6/pr98-24` at 19530f30ad7fd2fa5c4cd9dcba1150e355c715cd is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-2998783294 :rocket:



---
:rocket: The latest prerelease `access-esm1p6/pr98-29` at c1040cf9eea9847c43f7f4adcb4249659d380c77 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3002219224 :rocket:






---
:rocket: The latest prerelease `access-esm1p6/pr98-32` at ed77da12d95a8d765414fcb698439f84564d0af8 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3035365592 :rocket:






---
:rocket: The latest prerelease `access-esm1p6/pr98-35` at f515fb5ac66510b124d4585cbe42ce971b963d7d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3043603813 :rocket:




---
:rocket: The latest prerelease `access-esm1p6/pr98-36` at 1c14b3d96fe74927c95c4fa70a3a86a01702bdd7 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3047197860 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr98-37` at 38fc1fcb4e658a6628e925194fc7d73a8aa97541 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3047217079 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr98-53` at 5dfcc48a616ee40f8c837f0ad290a5d0e4050e2b is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3071666482 :rocket:


















---
:rocket: The latest prerelease `access-esm1p6/pr98-62` at 140ca54d21aef2900d6786b9757ebb315b683d1b is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3076772888 :rocket:










---
:rocket: The latest prerelease `access-esm1p6/pr98-63` at 6662e5a67aad2f40b5b95459115c07e6d7f69cf4 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3134910492 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr98-65` at fececb030d80a585646ac6115fbd69b80da301cc is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/98#issuecomment-3162078557 :rocket:

