### PR TITLE
Aicenmin tests

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.f5e323785ed29c3c2fd1cf8383592b204d3a9830=access-esm1.6'
+        - '@git.3d230d679b7216e8f7c5359a7af8b79198b110b8=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/f5e323785ed29c3c2fd1cf8383592b204d3a9830-{hash:7}'
+          cice5: '{name}/3d230d679b7216e8f7c5359a7af8b79198b110b8-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.ca5e54a1216e6430c6d10cb17f14f6f3c3d09a3f=access-esm1.6'
+        - '@git.59838bb11f790066ed3ef60d01f52b9ec265e64a=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/ca5e54a1216e6430c6d10cb17f14f6f3c3d09a3f-{hash:7}'
+          cice5: '{name}/59838bb11f790066ed3ef60d01f52b9ec265e64a-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+          - access-esm1p6@git.dev_2025.04.000 cice=5
   packages:
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.6fb5e3e5f1f105412febe31cc720658ee7c5f125=access-esm1.6'
+        - '@git.992de0854803328c13a86e82743677a7b17c37ac=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/6fb5e3e5f1f105412febe31cc720658ee7c5f125-{hash:7}'
+          cice5: '{name}/992de0854803328c13a86e82743677a7b17c37ac-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.c5f7222898f1c583024c10bcdbdd69575488c877=access-esm1.6'
+        - '@git.ccd78daf07935e3d099b259a009a30a41692f03b=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/c5f7222898f1c583024c10bcdbdd69575488c877-{hash:7}'
+          cice5: '{name}/ccd78daf07935e3d099b259a009a30a41692f03b-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.7e8ea3417fd7132a9654bd4a951d19a99972961f=access-esm1.6'
+        - '@git.76a4172775f88feb0cd27f57c37ae47c4f6be689=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/7e8ea3417fd7132a9654bd4a951d19a99972961f-{hash:7}'
+          cice5: '{name}/76a4172775f88feb0cd27f57c37ae47c4f6be689-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.adc0bae90c78ebe1b3f88390bc51608c58a5452b=access-esm1.6'
+        - '@git.f5e323785ed29c3c2fd1cf8383592b204d3a9830=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/adc0bae90c78ebe1b3f88390bc51608c58a5452b-{hash:7}'
+          cice5: '{name}/f5e323785ed29c3c2fd1cf8383592b204d3a9830-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.275e41a61183215f84f9e407e4e8736fa8b7c38b=access-esm1.6'
+        - '@git.d428b841da924280528c066ccdf116cbceb66f27=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/275e41a61183215f84f9e407e4e8736fa8b7c38b-{hash:7}'
+          cice5: '{name}/d428b841da924280528c066ccdf116cbceb66f27-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.522a380d004c2651a63aa1d436fcb6854d87db68=access-esm1.6'
+        - '@git.b538b67154addc5285b5f2ae53563970756b6959=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/522a380d004c2651a63aa1d436fcb6854d87db68-{hash:7}'
+          cice5: '{name}/b538b67154addc5285b5f2ae53563970756b6959-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.be4416352b421e6d89eeb61cd62a412e6d9acd62=access-esm1.6'
+        - '@git.ca5e54a1216e6430c6d10cb17f14f6f3c3d09a3f=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/be4416352b421e6d89eeb61cd62a412e6d9acd62-{hash:7}'
+          cice5: '{name}/ca5e54a1216e6430c6d10cb17f14f6f3c3d09a3f-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.b629e1a750362cbcf9949fef183371d2de94b80d=access-esm1.6'
+        - '@git.29cdd780d0e4a4ceab622ad1cf3a5aaedf720b8d=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/b629e1a750362cbcf9949fef183371d2de94b80d-{hash:7}'
+          cice5: '{name}/29cdd780d0e4a4ceab622ad1cf3a5aaedf720b8d-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.9d3a40963203cd0ba4ac721aa81d0ed3901934b4=access-esm1.6'
+        - '@git.adc0bae90c78ebe1b3f88390bc51608c58a5452b=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/9d3a40963203cd0ba4ac721aa81d0ed3901934b4-{hash:7}'
+          cice5: '{name}/adc0bae90c78ebe1b3f88390bc51608c58a5452b-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.fa937f7466c6151fc4b401e3a6f3c6f643ba4466=access-esm1.6'
+        - '@git.522a380d004c2651a63aa1d436fcb6854d87db68=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/fa937f7466c6151fc4b401e3a6f3c6f643ba4466-{hash:7}'
+          cice5: '{name}/522a380d004c2651a63aa1d436fcb6854d87db68-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.275e41a61183215f84f9e407e4e8736fa8b7c38b=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.8f4baf7971ff0bea3f94a2815ade87a71b246e61=access-esm1.6'
+        - '@git.1dfd797adc8d19131f8d6e3029a1cd65416d6c9b=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/8f4baf7971ff0bea3f94a2815ade87a71b246e61-{hash:7}'
+          cice5: '{name}/1dfd797adc8d19131f8d6e3029a1cd65416d6c9b-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000 cice=5
+    - access-esm1p6@git.dev_2025.04.000
   packages:
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.144fe4cf41d09e8e25ca72ea47080b635d3da571=access-esm1.6'
+        - '@git.ce970cdaa640889dab9454cbd7efaf9f628a2e8a=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/144fe4cf41d09e8e25ca72ea47080b635d3da571-{hash:7}'
+          cice5: '{name}/ce970cdaa640889dab9454cbd7efaf9f628a2e8a-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.58341324b6b2a300149377ff104948cd9d77c5e0=access-esm1.6'
+        - '@git.0ada2aaec2ab157146a1c2eb75a4f7f277290465=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/58341324b6b2a300149377ff104948cd9d77c5e0-{hash:7}'
+          cice5: '{name}/0ada2aaec2ab157146a1c2eb75a4f7f277290465-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
+        - '@git.9d3a40963203cd0ba4ac721aa81d0ed3901934b4=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
+          cice5: '{name}/9d3a40963203cd0ba4ac721aa81d0ed3901934b4-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.ac86ff39aae29ae950a992b68178685a7c7c9d92=access-esm1.6'
+        - '@git.fa937f7466c6151fc4b401e3a6f3c6f643ba4466=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/ac86ff39aae29ae950a992b68178685a7c7c9d92-{hash:7}'
+          cice5: '{name}/fa937f7466c6151fc4b401e3a6f3c6f643ba4466-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.b72f6cb36a4c3ae11699cdd1f86e217d1bdfd4bf=access-esm1.6'
+        - '@git.93ead49fc862e2d27519f8ed5c2b7c6c49aa6364=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/b72f6cb36a4c3ae11699cdd1f86e217d1bdfd4bf-{hash:7}'
+          cice5: '{name}/93ead49fc862e2d27519f8ed5c2b7c6c49aa6364-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.76a4172775f88feb0cd27f57c37ae47c4f6be689=access-esm1.6'
+        - '@git.ac86ff39aae29ae950a992b68178685a7c7c9d92=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/76a4172775f88feb0cd27f57c37ae47c4f6be689-{hash:7}'
+          cice5: '{name}/ac86ff39aae29ae950a992b68178685a7c7c9d92-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.d428b841da924280528c066ccdf116cbceb66f27=access-esm1.6'
+        - '@git.b629e1a750362cbcf9949fef183371d2de94b80d=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/d428b841da924280528c066ccdf116cbceb66f27-{hash:7}'
+          cice5: '{name}/b629e1a750362cbcf9949fef183371d2de94b80d-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.1dfd797adc8d19131f8d6e3029a1cd65416d6c9b=access-esm1.6'
+        - '@git.58341324b6b2a300149377ff104948cd9d77c5e0=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/1dfd797adc8d19131f8d6e3029a1cd65416d6c9b-{hash:7}'
+          cice5: '{name}/58341324b6b2a300149377ff104948cd9d77c5e0-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.1fa96bdf9e15462f0b85dc0a85544a62def41fe5=access-esm1.6'
+        - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/1fa96bdf9e15462f0b85dc0a85544a62def41fe5-{hash:7}'
+          cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.5'
+        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
+        - '@git.c5f7222898f1c583024c10bcdbdd69575488c877=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
+          cice5: '{name}/c5f7222898f1c583024c10bcdbdd69575488c877-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.59838bb11f790066ed3ef60d01f52b9ec265e64a=access-esm1.6'
+        - '@git.6fb5e3e5f1f105412febe31cc720658ee7c5f125=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/59838bb11f790066ed3ef60d01f52b9ec265e64a-{hash:7}'
+          cice5: '{name}/6fb5e3e5f1f105412febe31cc720658ee7c5f125-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.b538b67154addc5285b5f2ae53563970756b6959=access-esm1.6'
+        - '@git.be4416352b421e6d89eeb61cd62a412e6d9acd62=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/b538b67154addc5285b5f2ae53563970756b6959-{hash:7}'
+          cice5: '{name}/be4416352b421e6d89eeb61cd62a412e6d9acd62-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.3d230d679b7216e8f7c5359a7af8b79198b110b8=access-esm1.6'
+        - '@git.8f4baf7971ff0bea3f94a2815ade87a71b246e61=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/3d230d679b7216e8f7c5359a7af8b79198b110b8-{hash:7}'
+          cice5: '{name}/8f4baf7971ff0bea3f94a2815ade87a71b246e61-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.93ead49fc862e2d27519f8ed5c2b7c6c49aa6364=access-esm1.6'
+        - '@git.7e8ea3417fd7132a9654bd4a951d19a99972961f=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/93ead49fc862e2d27519f8ed5c2b7c6c49aa6364-{hash:7}'
+          cice5: '{name}/7e8ea3417fd7132a9654bd4a951d19a99972961f-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.29cdd780d0e4a4ceab622ad1cf3a5aaedf720b8d=access-esm1.6'
+        - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/29cdd780d0e4a4ceab622ad1cf3a5aaedf720b8d-{hash:7}'
+          cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.992de0854803328c13a86e82743677a7b17c37ac=access-esm1.6'
+        - '@git.275e41a61183215f84f9e407e4e8736fa8b7c38b=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/992de0854803328c13a86e82743677a7b17c37ac-{hash:7}'
+          cice5: '{name}/275e41a61183215f84f9e407e4e8736fa8b7c38b-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.6e57c13d1d70275d172b06e3cbdbb36c8d3b139e=access-esm1.6'
+        - '@git.b72f6cb36a4c3ae11699cdd1f86e217d1bdfd4bf=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/6e57c13d1d70275d172b06e3cbdbb36c8d3b139e-{hash:7}'
+          cice5: '{name}/b72f6cb36a4c3ae11699cdd1f86e217d1bdfd4bf-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.ce970cdaa640889dab9454cbd7efaf9f628a2e8a=access-esm1.6'
+        - '@git.1fa96bdf9e15462f0b85dc0a85544a62def41fe5=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/ce970cdaa640889dab9454cbd7efaf9f628a2e8a-{hash:7}'
+          cice5: '{name}/1fa96bdf9e15462f0b85dc0a85544a62def41fe5-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,15 +9,15 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+    - access-esm1p6@git.dev_2025.04.000 cice=5
   packages:
     mom5:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-    cice4:
+    cice5:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.5'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -62,12 +62,12 @@ spack:
       tcl:
         include:
           - access-esm1p6
-          - cice4
+          - cice5
           - um7
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          cice5: '{name}/0b2d87220a847463cded92f181d49520b9bc25d8-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file.
+# This is a Spack Environment file
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0996c7636bc45d4e3d95419f8e7838e1d1f05739=access-esm1.6'
+        - '@git.6e57c13d1d70275d172b06e3cbdbb36c8d3b139e=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/0996c7636bc45d4e3d95419f8e7838e1d1f05739-{hash:7}'
+          cice5: '{name}/6e57c13d1d70275d172b06e3cbdbb36c8d3b139e-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.ccd78daf07935e3d099b259a009a30a41692f03b=access-esm1.6'
+        - '@git.144fe4cf41d09e8e25ca72ea47080b635d3da571=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/ccd78daf07935e3d099b259a009a30a41692f03b-{hash:7}'
+          cice5: '{name}/144fe4cf41d09e8e25ca72ea47080b635d3da571-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.6'
+        - '@git.0996c7636bc45d4e3d95419f8e7838e1d1f05739=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/0b2d87220a847463cded92f181d49520b9bc25d8-{hash:7}'
+          cice5: '{name}/0996c7636bc45d4e3d95419f8e7838e1d1f05739-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:


### PR DESCRIPTION
A coupling issue in CM3 meant that larger values of `aicenmin`  caused water to disappear. The coupling is different in ESM1.6 – but just doing a few runs with different values as a sanity check

---
:rocket: The latest prerelease `access-esm1p6/pr100-12` at 27d1b547bf9f29da99f07efc5b0e5a7a62edf718 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/100#issuecomment-3011764577 :rocket:











