### PR TITLE
CICE calendar base versions

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.6'
+        - '@git.0bd0131c1c3d3ddeaf82490869b7973476d780e0=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/0b2d87220a847463cded92f181d49520b9bc25d8-{hash:7}'
+          cice5: '{name}/0bd0131c1c3d3ddeaf82490869b7973476d780e0-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0bd0131c1c3d3ddeaf82490869b7973476d780e0=access-esm1.6'
+        - '@git.f041c28c39f1aeccc3e62a685a081a2b7ed30dfa=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/0bd0131c1c3d3ddeaf82490869b7973476d780e0-{hash:7}'
+          cice5: '{name}/f041c28c39f1aeccc3e62a685a081a2b7ed30dfa-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.f041c28c39f1aeccc3e62a685a081a2b7ed30dfa=access-esm1.6'
+        - '@git.d0e070a970ac0c46b02a55039d30cf79787dbc40=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/f041c28c39f1aeccc3e62a685a081a2b7ed30dfa-{hash:7}'
+          cice5: '{name}/d0e070a970ac0c46b02a55039d30cf79787dbc40-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.5'
+        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.f9c39788a936ae988a07e082be06e459c5e2182e=access-esm1.6'
+        - '@git.0bd0131c1c3d3ddeaf82490869b7973476d780e0=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/f9c39788a936ae988a07e082be06e459c5e2182e-{hash:7}'
+          cice5: '{name}/0bd0131c1c3d3ddeaf82490869b7973476d780e0-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,15 +9,15 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.04.000
+    - access-esm1p6@git.dev_2025.04.000 cice=5
   packages:
     mom5:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-    cice4:
+    cice5:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - '@git.0b2d87220a847463cded92f181d49520b9bc25d8=access-esm1.5'
     um7:
       require:
         - '@git.access-esm1.6-2025.04.000=access-esm1.6'
@@ -62,12 +62,12 @@ spack:
       tcl:
         include:
           - access-esm1p6
-          - cice4
+          - cice5
           - um7
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          cice5: '{name}/0b2d87220a847463cded92f181d49520b9bc25d8-{hash:7}'
           um7: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.0bd0131c1c3d3ddeaf82490869b7973476d780e0=access-esm1.6'
+        - '@git.f9c39788a936ae988a07e082be06e459c5e2182e=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.04.000'
-          cice5: '{name}/0bd0131c1c3d3ddeaf82490869b7973476d780e0-{hash:7}'
+          cice5: '{name}/f9c39788a936ae988a07e082be06e459c5e2182e-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:


### PR DESCRIPTION
For comparison

---
:rocket: The latest prerelease `access-esm1p6/pr102-1` at 4cebed0dc2a06f4a91e45f58cb094da5625461aa is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/102#issuecomment-3002759786 :rocket:
