### PR TITLE
initialisation of zse_vec

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.06.000
+    - access-esm1p6@latest
   packages:
     mom5:
       require:
@@ -20,7 +20,7 @@ spack:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.2602f627b551eefe62d06e1eda91410e23adc823=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
+          um7: '{name}/2602f627b551eefe62d06e1eda91410e23adc823.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
Add the initialisation of zse_vec to UM7 for compatibility with upcoming CABLE changes due to GW integration.

---
:rocket: The latest prerelease `access-esm1p6/pr104-1` at 1625175da8bdeeac67f3114f7835248e3c3fcb51 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/104#issuecomment-3011625904 :rocket:


