### PR TITLE
Basinfixes+cice4

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.c03ba703c73eac49cd9a03de1f79dc5ed98e471c=access-esm1.6'
+        - '@git.5842a142a1296ed9cba5cddfc351952bbb8ed4fe=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/c03ba703c73eac49cd9a03de1f79dc5ed98e471c-{hash:7}'
+          um7: '{name}/5842a142a1296ed9cba5cddfc351952bbb8ed4fe-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.c38938c5b7e1b6d9fc4c85127fbb5a66cb5dbf7f=access-esm1.6'
+        - '@git.471a41c93386bff96083a7da5fded8baacd7b22b=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/c38938c5b7e1b6d9fc4c85127fbb5a66cb5dbf7f-{hash:7}'
+          um7: '{name}/471a41c93386bff96083a7da5fded8baacd7b22b-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.dc61acabd4bed7fb343f700dcf76e2a8b30c3adb=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
+          um7: '{name}/dc61acabd4bed7fb343f700dcf76e2a8b30c3adb-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.ce81470f12c8a86034139ff738008891f2a51654=access-esm1.6'
+        - '@git.3c73fb9b281ded56deb281738dee6a500aa30b5b=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/ce81470f12c8a86034139ff738008891f2a51654-{hash:7}'
+          um7: '{name}/3c73fb9b281ded56deb281738dee6a500aa30b5b-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.6b63a497ae94c94d2d4a30263e2afb8d49304b3e=access-esm1.6'
+        - '@git.4d7a3a809bf04bf844839ca23c7472045966f5da=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/6b63a497ae94c94d2d4a30263e2afb8d49304b3e-{hash:7}'
+          um7: '{name}/4d7a3a809bf04bf844839ca23c7472045966f5da-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.087c9a02c661cb9d07bdfebe593b9299992f579c=access-esm1.6'
+        - '@git.c03ba703c73eac49cd9a03de1f79dc5ed98e471c=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/087c9a02c661cb9d07bdfebe593b9299992f579c-{hash:7}'
+          um7: '{name}/c03ba703c73eac49cd9a03de1f79dc5ed98e471c-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.414e8c1430eb2fc2d1954ebd4b46f456b53b2cca=access-esm1.6'
+        - '@git.2e936beb3ca360ba0801b3bf2ff79cf7ab38d008=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/414e8c1430eb2fc2d1954ebd4b46f456b53b2cca-{hash:7}'
+          um7: '{name}/2e936beb3ca360ba0801b3bf2ff79cf7ab38d008-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,18 +9,18 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.06.000
+    - access-esm1p6@git.dev_2025.06.000 cice=5
   packages:
     mom5:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-    cice4:
+    cice5:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.7233fc5e566b56d02ebb59c2a1e500052caee0b4=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -67,8 +67,8 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
-          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
+          cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
+          um7: '{name}/7233fc5e566b56d02ebb59c2a1e500052caee0b4-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.7233fc5e566b56d02ebb59c2a1e500052caee0b4=access-esm1.6'
+        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/7233fc5e566b56d02ebb59c2a1e500052caee0b4-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.730d67bc9a19b34be950dfeede02a02a2150a9ad=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -62,13 +62,13 @@ spack:
       tcl:
         include:
           - access-esm1p6
-          - cice4
+          - cice5
           - um7
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
+          um7: '{name}/730d67bc9a19b34be950dfeede02a02a2150a9ad-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.551b35c8bd3c7c6bd3c37fe0bf6d1d9e87063a00=access-esm1.6'
+        - '@git.7233fc5e566b56d02ebb59c2a1e500052caee0b4=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/551b35c8bd3c7c6bd3c37fe0bf6d1d9e87063a00-{hash:7}'
+          um7: '{name}/7233fc5e566b56d02ebb59c2a1e500052caee0b4-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,15 +9,15 @@
 # - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.06.000 cice=5
+    - access-esm1p6@git.dev_2025.06.000
   packages:
     mom5:
       require:
         - '@git.dev-2025.03.001=access-esm1.6'
         - '+access-gtracers'
-    cice5:
+    cice4:
       require:
-        - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
+        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
         - '@git.fa3d70a5aaf614e9abc3d2b239775c19b93a2de3=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
-          cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
+          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
           um7: '{name}/fa3d70a5aaf614e9abc3d2b239775c19b93a2de3-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.5842a142a1296ed9cba5cddfc351952bbb8ed4fe=access-esm1.6'
+        - '@git.930d01719a0709ce9dcc69554d47ce5e04e8695d=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/5842a142a1296ed9cba5cddfc351952bbb8ed4fe-{hash:7}'
+          um7: '{name}/930d01719a0709ce9dcc69554d47ce5e04e8695d-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
     um7:
       require:
-        - '@git.7233fc5e566b56d02ebb59c2a1e500052caee0b4=access-esm1.6'
+        - '@git.551b35c8bd3c7c6bd3c37fe0bf6d1d9e87063a00=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
-          um7: '{name}/7233fc5e566b56d02ebb59c2a1e500052caee0b4-{hash:7}'
+          um7: '{name}/551b35c8bd3c7c6bd3c37fe0bf6d1d9e87063a00-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -62,7 +62,7 @@ spack:
       tcl:
         include:
           - access-esm1p6
-          - cice5
+          - cice4
           - um7
           - mom5
         projections:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.4d7a3a809bf04bf844839ca23c7472045966f5da=access-esm1.6'
+        - '@git.f8cdacd8ecd05bf782f8071a187e61422a1770b5=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/4d7a3a809bf04bf844839ca23c7472045966f5da-{hash:7}'
+          um7: '{name}/f8cdacd8ecd05bf782f8071a187e61422a1770b5-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.2e936beb3ca360ba0801b3bf2ff79cf7ab38d008=access-esm1.6'
+        - '@git.c38938c5b7e1b6d9fc4c85127fbb5a66cb5dbf7f=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/2e936beb3ca360ba0801b3bf2ff79cf7ab38d008-{hash:7}'
+          um7: '{name}/c38938c5b7e1b6d9fc4c85127fbb5a66cb5dbf7f-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - '+access-gtracers'
     cice5:
       require:
-        - '@git.c604d73bbdfcf12d7d7865ace26304103ee96808=access-esm1.6'
+        - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
         - '@git.551b35c8bd3c7c6bd3c37fe0bf6d1d9e87063a00=access-esm1.6'
@@ -67,7 +67,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
-          cice5: '{name}/c604d73bbdfcf12d7d7865ace26304103ee96808-{hash:7}'
+          cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
           um7: '{name}/551b35c8bd3c7c6bd3c37fe0bf6d1d9e87063a00-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.930d01719a0709ce9dcc69554d47ce5e04e8695d=access-esm1.6'
+        - '@git.ce81470f12c8a86034139ff738008891f2a51654=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/930d01719a0709ce9dcc69554d47ce5e04e8695d-{hash:7}'
+          um7: '{name}/ce81470f12c8a86034139ff738008891f2a51654-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.3c73fb9b281ded56deb281738dee6a500aa30b5b=access-esm1.6'
+        - '@git.fa3d70a5aaf614e9abc3d2b239775c19b93a2de3=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/3c73fb9b281ded56deb281738dee6a500aa30b5b-{hash:7}'
+          um7: '{name}/fa3d70a5aaf614e9abc3d2b239775c19b93a2de3-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.730d67bc9a19b34be950dfeede02a02a2150a9ad=access-esm1.6'
+        - '@git.6b63a497ae94c94d2d4a30263e2afb8d49304b3e=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/730d67bc9a19b34be950dfeede02a02a2150a9ad-{hash:7}'
+          um7: '{name}/6b63a497ae94c94d2d4a30263e2afb8d49304b3e-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.access-esm1.6-2025.04.000=access-esm1.5'
     um7:
       require:
-        - '@git.fa3d70a5aaf614e9abc3d2b239775c19b93a2de3=access-esm1.6'
+        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
-          um7: '{name}/fa3d70a5aaf614e9abc3d2b239775c19b93a2de3-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.f8cdacd8ecd05bf782f8071a187e61422a1770b5=access-esm1.6'
+        - '@git.414e8c1430eb2fc2d1954ebd4b46f456b53b2cca=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/f8cdacd8ecd05bf782f8071a187e61422a1770b5-{hash:7}'
+          um7: '{name}/414e8c1430eb2fc2d1954ebd4b46f456b53b2cca-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
         - '@git.5550626e7d1b0ed1d93f2f5f591b95cece3fc39d=access-esm1.6'
     um7:
       require:
-        - '@git.471a41c93386bff96083a7da5fded8baacd7b22b=access-esm1.6'
+        - '@git.087c9a02c661cb9d07bdfebe593b9299992f579c=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'
@@ -68,7 +68,7 @@ spack:
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
           cice5: '{name}/5550626e7d1b0ed1d93f2f5f591b95cece3fc39d-{hash:7}'
-          um7: '{name}/471a41c93386bff96083a7da5fded8baacd7b22b-{hash:7}'
+          um7: '{name}/087c9a02c661cb9d07bdfebe593b9299992f579c-{hash:7}'
           mom5: '{name}/dev-2025.03.001-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
Tests for running the UM basin fixes with CICE4.

---
:rocket: The latest prerelease `access-esm1p6/pr109-6` at 9dd8e903a676975d0ce622eb9ea1aaa58fcf96f7 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/109#issuecomment-3096871094 :rocket:





