### PR TITLE
test building latest mom5 & cice5 together

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.002"
+    "spack-packages": "2025.07.003"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.003"
+    "spack-packages": "main"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,18 +6,17 @@
 # Build with:
 # - UM7 from dev-access-esm1.6 branch
 # - MOM5 from development branch
-# - CICE4 from ESM1.5 and change to CICE5 once CICE5 SPR has been updated.
+# - CICE5 from development branch
 spack:
   specs:
-    - access-esm1p6@git.dev_2025.06.000
+    - access-esm1p6@git.dev_2025.06.000 cice=5
   packages:
     mom5:
       require:
-        - '@git.dev-2025.03.001=access-esm1.6'
-        - '+access-gtracers'
-    cice4:
+        - '@git.2025.05.000=access-esm1.6'
+    cice5:
       require:
-        - '@git.access-esm1.6-2025.04.000=access-esm1.5'
+        - '@git.3ce7ce803fb1594fc8f70102ecb28ae48e73c229=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -41,13 +40,13 @@ spack:
         - '@1.10.11'
     access-fms:
       require:
-        - '@git.mom5-2025.04.001'
+        - '@git.mom5-2025.05.000=mom5'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.04.001'
+        - '@git.dev-2025.05.001=development'
     access-mocsy:
       require:
-        - '@git.2017.12.0'
+        - '@git.2025.07.001=gtracers'
 
     # Preferences for all packages
     all:
@@ -62,14 +61,14 @@ spack:
       tcl:
         include:
           - access-esm1p6
-          - cice4
+          - cice5
           - um7
           - mom5
         projections:
           access-esm1p6: '{name}/dev_2025.06.000'
-          cice4: '{name}/access-esm1.6-2025.04.000-{hash:7}'
+          cice5: '{name}/3ce7ce803fb1594fc8f70102ecb28ae48e73c229-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
-          mom5: '{name}/dev-2025.03.001-{hash:7}'
+          mom5: '{name}/2025.05.000-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr111-4` at 3fb83122e2ea9ef6446e7b732856eed2313fd8ac is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/111#issuecomment-3082724407 :rocket:



