### PR TITLE
Swap to oneapi 2025.2.0

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -28,7 +28,7 @@ spack:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@5.0.5'
     netcdf-c:
       require:
         - '@4.9.2'


### PR DESCRIPTION
Prerelease build for a parallel run to AugustSpinup using oneapi. 

The goal is to run ~100 years and compare the climate

---
:rocket: The latest prerelease `access-esm1p6/pr118-4` at ffd1c871c11bba474b0f866a30f369e725c87817 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/118#issuecomment-3199198291 :rocket:



