### PR TITLE
Try running only the cice initialisation

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.0e9eb2b67ff076bce49440f7afc88bceb04bf1aa=access-esm1.6'
+        - '@git.028bd2431f438242855a8767bc8e62d16df0a96f=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -66,7 +66,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2025.07.000'
-          cice5: '{name}/0e9eb2b67ff076bce49440f7afc88bceb04bf1aa-{hash:7}'
+          cice5: '{name}/028bd2431f438242855a8767bc8e62d16df0a96f-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.21467fe13ba8e1faf93347f39206faec8094a955=access-esm1.6'
+        - '@git.72075d86b24abfe48b56cbd1ce8576dd0474a6bb=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -66,7 +66,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2025.07.000'
-          cice5: '{name}/21467fe13ba8e1faf93347f39206faec8094a955-{hash:7}'
+          cice5: '{name}/72075d86b24abfe48b56cbd1ce8576dd0474a6bb-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.72075d86b24abfe48b56cbd1ce8576dd0474a6bb=access-esm1.6'
+        - '@git.97405f816a9cfb1af4102a41a2cd5fc686feebb5=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -66,7 +66,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2025.07.000'
-          cice5: '{name}/72075d86b24abfe48b56cbd1ce8576dd0474a6bb-{hash:7}'
+          cice5: '{name}/97405f816a9cfb1af4102a41a2cd5fc686feebb5-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -28,7 +28,7 @@ spack:
         - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@5.0.5'
     netcdf-c:
       require:
         - '@4.9.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.access-esm1.6-2025.07.001=access-esm1.6'
+        - '@git.21467fe13ba8e1faf93347f39206faec8094a955=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -66,7 +66,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2025.07.000'
-          cice5: '{name}/access-esm1.6-2025.07.001-{hash:7}'
+          cice5: '{name}/21467fe13ba8e1faf93347f39206faec8094a955-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.97405f816a9cfb1af4102a41a2cd5fc686feebb5=access-esm1.6'
+        - '@git.0e9eb2b67ff076bce49440f7afc88bceb04bf1aa=access-esm1.6'
     um7:
       require:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
@@ -66,7 +66,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2025.07.000'
-          cice5: '{name}/97405f816a9cfb1af4102a41a2cd5fc686feebb5-{hash:7}'
+          cice5: '{name}/0e9eb2b67ff076bce49440f7afc88bceb04bf1aa-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:


### PR DESCRIPTION
Attempting to debug the CICE coupling namelist failure

---
:rocket: The latest prerelease `access-esm1p6/pr120-6` at 3c966b877e97ca0ee502f66e84a94b566e7318e4 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/120#issuecomment-3208770531 :rocket:





