### PR TITLE
Use explicit versions of access-generic-tracers and access-mocsy

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.006"
+    "spack-packages": "2025.08.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -43,10 +43,10 @@ spack:
         - '@git.mom5-2025.05.000=mom5'
     access-generic-tracers:
       require:
-        - '@git.2025.07.001=main'
+        - '@2025.07.001'
     access-mocsy:
       require:
-        - '@git.2025.07.002=gtracers'
+        - '@2025.07.002'
 
     # Preferences for all packages
     all:


### PR DESCRIPTION
This is a non-answer-changing update to the 2025.07.000 release to use explicit versions of access-generic-tracers and access-mocsy in the `spack.yaml`.

Configurations need not be updated to use this release since it is ~effectively~ identical to 2025.07.000. The change is only made so that people can use the `spack.yaml` on the `main` branch of this repo with the latest version of `spack-packages`.

---
:rocket: The latest prerelease `access-esm1p6/pr122-1` at 6ff899d1ea4604249b4867bacbc8f7b1e069fc6c is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/122#issuecomment-3203974035 :rocket:
