### PR TITLE
Build oasis3-mct from master branch

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.000"
+    "spack-packages": "59bf398c2f482a47cd28c641589dfcfa7ae84cca"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.2025.03.001=access-esm1.5'
+        - '@git.2025.03.001=access-om2'
     openmpi:
       require:
         - '@4.1.5'


### PR DESCRIPTION
This PR is to create a prerelease of ACCESS-ESM1.6 using oasis3-mct built from the master branch (rather than the access-esm1.5 branch)

---
:rocket: The latest prerelease `access-esm1p6/pr123-2` at 14421f174933527a7db46d04ddd86182aec6b015 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/123#issuecomment-3226183652 :rocket:

