### PR TITLE
Update to oneAPI@2025.2.0 and OpenMPI@5.0.8

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.003"
+    "spack-packages": "2025.09.001"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.07.001 cice=5
+    - access-esm1p6@git.2025.09.000 cice=5
   packages:
     mom5:
       require:
@@ -22,13 +22,13 @@ spack:
         - '@git.access-esm1.6-2025.06.000=access-esm1.6'
     gcom4:
       require:
-        - '@git.2024.05.28=access-esm1.5'
+        - '@git.2025.08.000=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
+        - '@git.2025.03.001'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@5.0.8'
     netcdf-c:
       require:
         - '@4.9.2'
@@ -47,11 +47,18 @@ spack:
     access-mocsy:
       require:
         - '@2025.07.002'
+    gcc-runtime:
+      require:
+        - '%gcc'
+    glibc:
+      require:
+        - '@2.28'
+        - '%gcc'
 
     # Preferences for all packages
     all:
       require:
-        - '%intel@2021.10.0'
+        - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:
@@ -65,7 +72,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.07.001'
+          access-esm1p6: '{name}/2025.09.000'
           cice5: '{name}/access-esm1.6-2025.07.001-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr126-16` at 0db84afc169aa942bf5cf2517d1fe8d904e584cb is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/126#issuecomment-3290507619 :rocket:




















