### PR TITLE
2025.07.000 with access-generic-tracers@2025.04.001

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -43,7 +43,7 @@ spack:
         - '@git.mom5-2025.05.000=mom5'
     access-generic-tracers:
       require:
-        - '@git.2025.07.001=main'
+        - '@git.2025.04.001=main'
     access-mocsy:
       require:
         - '@git.2025.07.002=gtracers'


### PR DESCRIPTION
The PR is to create a prerelease deployment that is identical to 2025.07.000 but with access-generic-tracers reverted to 2025.04.001. This is for debugging https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/182

---
:rocket: The latest prerelease `access-esm1p6/pr127-1` at 6ede6578139a8a3c54eff2d6c0135da4ee446c3f is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/127#issuecomment-3218699912 :rocket:
