### PR TITLE
UM7 commit with vcmax change

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.16b3bc52f18119243c4277c62db86e69b2168e5b=access-esm1.6'
+        - '@git.57959ffcc4b2d8bb1924fbd65c2dbe716477003a=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.17d4400cfc1c2426b9bfad3155e8310d64dc4423=access-esm1.6'
+        - '@git.0e12025cb513c1104839ce7ad7cee0851ffc6a25=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.16b3bc52f18119243c4277c62db86e69b2168e5b=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.57959ffcc4b2d8bb1924fbd65c2dbe716477003a=access-esm1.6'
+        - '@git.17d4400cfc1c2426b9bfad3155e8310d64dc4423=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'


### PR DESCRIPTION
Testing changes for vcmax for Australian PFTs (see https://github.com/ACCESS-NRI/UM7/pull/145)

---
:rocket: The latest prerelease `access-esm1p6/pr129-4` at fa7dd9026d8c4ddf8cff3b8f9e5e8e237c303028 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/129#issuecomment-3322531443 :rocket:



