### PR TITLE
Remove mlogmax from CABLE

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.079658cbef7e1d5a6170d961a6f673e43c6dbb23=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr130-1` at b60cea930a2792a60460b9d964acb5154d82cccc is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/130#issuecomment-3232121654 :rocket:
