### PR TITLE
UM7 commit with new PFT names

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.ab4a44fa68812f0c536f0eb09c31a47c98c3b11d=access-esm1.6'
+        - '@git.ffdc3e9e34a5c580587f22f5642aca732524dd7e=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'


### PR DESCRIPTION
This build is using the `rename-aust-pfts` branch from UM7, see PR https://github.com/ACCESS-NRI/UM7/pull/147 for details of the changes.

- `access-esm1p6/pr131-4` contains all the changes, using UM7 commit 55926453c958f3454888f13c553239c759e384ad
- `access-esm1p6/pr131-5` contains only the changes to the names, no changes to any condition, using UM7 commit ff7529166a78427ce2d3ff2a7a0caedb64dec421
- `access-esm1p6/pr131-6` contains all the changes but the LAI clobbering change, using UM7 commit beb9f2602059f9cd1d932fd39e14f82c028f12fe
- `access-esm1p6/pr131-7` contains all the changes but the phen%phase=2 change, using UM7 commit ab4a44fa68812f0c536f0eb09c31a47c98c3b11d
- `access-esm1p6/pr131-8` contains all the changes but the LAI clobbering only include the change of factor and not the recoding of the condition, using UM7 commit ffdc3e9e34a5c580587f22f5642aca732524dd7e

---
:rocket: The latest prerelease `access-esm1p6/pr131-4` at 3d0bc78bbfc826516957c8b1d58023270468b9a6 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/131#issuecomment-3244105847 :rocket:





---
:rocket: The latest prerelease `access-esm1p6/pr131-5` at b4053db1c0b0b534fb7635054d4362a6cd75773d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/131#issuecomment-3305363428 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr131-6` at a3e762d41114317549a83892f389e8032886de62 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/131#issuecomment-3305465417 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr131-7` at eb6cd40887de5631e491b243870c7a47433218de is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/131#issuecomment-3305522014 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr131-8` at dc08da2a6b7d606ba6b4a8b9d817c76cc34371bf is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/131#issuecomment-3305718474 :rocket:
