### PR TITLE
Release 2025.07.001 with WOMBAT bugfix

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.000"
+    "spack-packages": "2025.08.003"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.07.000 cice=5
+    - access-esm1p6@git.2025.07.001 cice=5
   packages:
     mom5:
       require:
@@ -43,7 +43,7 @@ spack:
         - '@git.mom5-2025.05.000=mom5'
     access-generic-tracers:
       require:
-        - '@2025.07.001'
+        - '@2025.08.000'
     access-mocsy:
       require:
         - '@2025.07.002'
@@ -65,7 +65,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.07.000'
+          access-esm1p6: '{name}/2025.07.001'
           cice5: '{name}/access-esm1.6-2025.07.001-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'


### PR DESCRIPTION
This PR is for a minor release update to include the fix for the intermittent WOMBAT crashes described [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/182).

---
:rocket: The latest prerelease `access-esm1p6/pr133-1` at d2c6efa0997bf16dd25910beaac83b524c7f918d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/133#issuecomment-3235822686 :rocket:
