### PR TITLE
Latest UM7 updates before renaming Aust. PFTs

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.6602dadd15c190ee37c6644190f52d428bc66917=access-esm1.6'
     gcom4:
       require:
         - '@git.2024.05.28=access-esm1.5'


### PR DESCRIPTION
This build points to the base commit for the branch renaming the Aust. PFTs constants. This is used to ensure the renaming is not introducing changes.

This build is used [with the updated config with the new PFT distribution](https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/194).

---
:rocket: The latest prerelease `access-esm1p6/pr134-1` at b7799c4e72e7eee40fc6d7aa791381dba4222c79 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/134#issuecomment-3244001358 :rocket:
