### PR TITLE
Update to access-generic-tracers@2025.09.000

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.09.001"
+    "spack-packages": "2025.09.004"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.09.000 cice=5
+    - access-esm1p6@git.2025.09.001 cice=5
   packages:
     mom5:
       require:
@@ -43,7 +43,7 @@ spack:
         - '@git.mom5-2025.05.000=mom5'
     access-generic-tracers:
       require:
-        - '@2025.08.000'
+        - '@2025.09.000'
     access-mocsy:
       require:
         - '@2025.07.002'
@@ -72,7 +72,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.09.000'
+          access-esm1p6: '{name}/2025.09.001'
           cice5: '{name}/access-esm1.6-2025.07.001-{hash:7}'
           um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'


### PR DESCRIPTION
A minor update to the version of access-generic-tracers requested by @pearseb. This version of generic-tracers includes the [recent change to ensure that the PI slope of chlorophyll growth can only be max 3x the PI slope of carbon growth](https://github.com/ACCESS-NRI/GFDL-generic-tracers/pull/74). 

---
:rocket: The latest prerelease `access-esm1p6/pr137-2` at e58ee28e92bc7950d2f1aa783b24cbd53c68d74c is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/137#issuecomment-3316492495 :rocket:

