### PR TITLE
Build with albedo-scaling branch

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.f471c847e8c29989ea4fdb7ad24ee9bf86731437=access-esm1.6'
     gcom4:
       require:
         - '@git.2025.08.000=access-esm1.5'
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2025.09.001'
           cice5: '{name}/access-esm1.6-2025.07.001-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
+          um7: '{name}/f471c847e8c29989ea4fdb7ad24ee9bf86731437-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr138-1` at aaa96d98be1a94b05fae190adffa0fe776d64033 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/138#issuecomment-3322016618 :rocket:

