### PR TITLE
build exe to test using logical vcmax prognostic switch

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.07.001=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.06.000=access-esm1.6'
+        - '@git.4e24a75c327ba4ce8cb0e6ab296abbc04b3a27fa=access-esm1.6'
     gcom4:
       require:
         - '@git.2025.08.000=access-esm1.5'
@@ -74,7 +74,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2025.09.001'
           cice5: '{name}/access-esm1.6-2025.07.001-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.06.000-{hash:7}'
+          um7: '{name}/4e24a75c327ba4ce8cb0e6ab296abbc04b3a27fa-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
 inplace of icycle =1. should be zero difference but strictly icycle is the wrong switch

---
:rocket: The latest prerelease `access-esm1p6/pr140-1` at 313dbd93d97f400b63f8d06ca51da2d327fbdcae is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/140#issuecomment-3325895689 :rocket:

