### PR TITLE
Compile before UM changes for Sept. spinup

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.09.000=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.09.000=access-esm1.6'
+        - '@git.06a831a4e82d41f01fee228de0198d1f8f87a736=access-esm1.6'
     gcom4:
       require:
         - '@git.2025.08.000=access-esm1.5'


### PR DESCRIPTION
This compiles the UM7 at the latest UM change before the September's merges. All other codes are the same as used in September spinup.

Commit for UM7, compiler fixes by Manodeep: [06a831a4e82d41f01fee228de0198d1f8f87a736](https://github.com/ACCESS-NRI/UM7/commit/06a831a4e82d41f01fee228de0198d1f8f87a736)

---
:rocket: The latest prerelease `access-esm1p6/pr152-1` at 2d8a9213ce65d0074f52a960ffa77c8d3853e5db is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/152#issuecomment-3383977321 :rocket:
