### PR TITLE
Fix for the carbon

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.09.002 cice=5
+    - access-esm1p6@git.2025.10.000 cice=5
   packages:
     mom5:
       require:
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.09.000=access-esm1.6'
     um7:
       require:
-        - '@git.access-esm1.6-2025.09.000=access-esm1.6'
+        - '@git.access-esm1.6-2025.10.000=access-esm1.6'
     gcom4:
       require:
         - '@git.2025.08.000=access-esm1.5'
@@ -72,9 +72,9 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.09.002'
+          access-esm1p6: '{name}/2025.10.000'
           cice5: '{name}/access-esm1.6-2025.09.000-{hash:7}'
-          um7: '{name}/access-esm1.6-2025.09.000-{hash:7}'
+          um7: '{name}/access-esm1.6-2025.10.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
This is using the latest UM version (2025.10.000) that includes a fix for vcmax. This corrects an anormalously low GPP in the previous version.

---
:rocket: The latest prerelease `access-esm1p6/pr154-1` at 1b089097573954e6d942140e77b85bcd9913f71d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/154#issuecomment-3395829062 :rocket:
