### PR TITLE
Check with older ompi5

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -28,7 +28,7 @@ spack:
         - '@git.2025.03.001'
     openmpi:
       require:
-        - '@5.0.5'
+        - '@5.0.8'
     netcdf-c:
       require:
         - '@4.9.2'
@@ -59,7 +59,7 @@ spack:
     all:
       require:
         - '%oneapi@2025.2.0'
-        - 'target=x86_64_v4'
+        - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
Do not merge. For debugging only

---
:rocket: The latest prerelease `access-esm1p6/pr155-3` at 659867bb9bf37d79cc365c26162700c5f2518392 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/155#issuecomment-3453726375 :rocket:



