### PR TITLE
consistent test requires backwards compatibility

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - '@git.access-esm1.6-2025.09.000=access-esm1.6'
     um7:
       require:
-        - '@git.2025.11.000=access-esm1.6'
+        - '@git.55a4fc99e2f4a59ead48feb85c567f331222c375=access-esm1.6'
     cable:
       require:
         - '@2025.11.000'
@@ -78,7 +78,7 @@ spack:
         projections:
           access-esm1p6: '{name}/2025.11.000'
           cice5: '{name}/access-esm1.6-2025.09.000-{hash:7}'
-          um7: '{name}/2025.11.000-{hash:7}'
+          um7: '{name}/55a4fc99e2f4a59ead48feb85c567f331222c375-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p6/pr165-1` at cb1502ee887fab5e6c34a8947ddd391a76e6d7c5 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/165#issuecomment-3519476247 :rocket:
