### PR TITLE
Update CICE5 with updates for CMIP7 variables

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.eb9583d3150c220060619331c5bf94a22f12c605=access-esm1.6'
+        - '@git.access-esm1.6-2025.11.000=access-esm1.6'
     um7:
       require:
         - '@git.2025.11.000=access-esm1.6'
@@ -77,7 +77,7 @@ spack:
           - mom5
         projections:
           access-esm1p6: '{name}/2025.11.001'
-          cice5: '{name}/access-esm1.6-2025.09.000-{hash:7}'
+          cice5: '{name}/access-esm1.6-2025.11.000-{hash:7}'
           um7: '{name}/2025.11.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:


### PR DESCRIPTION
This moves to latest cice5, with changes for cmip7 variables

---
:rocket: The latest prerelease `access-esm1p6/pr166-1` at 8815d6de7716c7e16647e2787e5e795b43026dca is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/166#issuecomment-3524387549 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr166-4` at 55f50f1101c9a238aaf0b1724dddc8f1e7adcca5 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/166#issuecomment-3524579630 :rocket:


