### PR TITLE
Infra Update `v8`: `spack v1` Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,9 +13,8 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p6
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p6

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -11,11 +11,9 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
-      root-sbd: access-esm1p6
     permissions:
       pull-requests: write
       contents: write
@@ -27,7 +25,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p6
     permissions:
       pull-requests: write
       contents: write
@@ -39,7 +36,6 @@ jobs:
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0
-      root-sbd: access-esm1p6
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,12 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
       root-sbd: access-esm1p6
     permissions:
@@ -24,7 +24,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p6
@@ -35,7 +35,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p6
       pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p6
-      pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
@@ -37,6 +35,4 @@ jobs:
     name: Closed
     if: github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
-    with:
-      root-sbd: access-esm1p6
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p6
@@ -36,7 +36,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: access-esm1p6
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2026.02.000"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.0",
+  "access-spack-packages": "2025.11.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.0",
+  "spack": "1.1",
   "access-spack-packages": "2025.11.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.11.001"
+  "access-spack-packages": "2025.11.001",
+  "custom-scopes": ["ukmo-restricted-scope"]
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.11.001",
-  "custom-scopes": ["ukmo-restricted-scope"]
+  "access-spack-packages": "2026.02.002",
+  "custom-scopes": [
+    "ukmo-restricted-scope"
+  ]
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,69 +9,69 @@
 # - CICE5
 spack:
   specs:
-    - access-esm1p6@git.2026.02.000 cice=5
+  - access-esm1p6@git.2026.02.000 cice=5
   packages:
     # Coupler
     oasis3-mct:
       require:
-        - '@5.2'
+      - '@5.2'
     # Major components
     cice5:
       require:
-        - '@2026.01.000'
-        - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
+      - '@2026.01.000'
+      - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-        - '@git.2026.02.000=access-esm1.6'
+      - '@git.2026.02.000=access-esm1.6'
     cable:
       require:
-        - '@2025.11.000'
-        - library=access-esm1.6
+      - '@2025.11.000'
+      - library=access-esm1.6
     mom5:
       require:
-        - '@git.2025.05.000=access-esm1.6'
+      - '@git.2025.05.000=access-esm1.6'
     # Model dependencies
     # MOM5
     access-fms:
       require:
-        - '@git.mom5-2025.08.000=mom5'
+      - '@git.mom5-2025.08.000=mom5'
     access-generic-tracers:
       require:
-        - '@2025.09.000'
+      - '@2025.09.000'
     access-mocsy:
       require:
-        - '@2025.07.002'
+      - '@2025.07.002'
     # UM7
     gcom4:
       require:
-        - '@git.2025.08.000=access-esm1.5'
+      - '@git.2025.08.000=access-esm1.5'
     # Shared dependencies
     openmpi:
       require:
-        - '@5.0.8'
+      - '@5.0.8'
     netcdf-c:
       require:
-        - '@4.9.2'
+      - '@4.9.2'
     netcdf-fortran:
       require:
-        - '@4.6.1'
+      - '@4.6.1'
     hdf5:
       require:
-        - '@1.14.3'
+      - '@1.14.3'
     # System dependencies
     gcc-runtime:
       require:
-        - '%gcc'
+      - '%gcc'
     glibc:
       require:
-        - '@2.28'
-        - '%gcc'
+      - '@2.28'
+      - '%gcc'
 
     # Preferences for all packages
     all:
       require:
-        - '%oneapi@2025.2.0'
-        - 'target=x86_64_v4'
+      - '%oneapi@2025.2.0'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -79,9 +79,3 @@ spack:
   view: true
   concretizer:
     unify: true
-  config:
-    install_tree:
-      root: $spack/../restricted/ukmo/release
-    source_cache: $spack/../restricted/ukmo/source_cache
-    build_stage:
-      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,8 +8,12 @@
 # - MOM5 from master branch with access-generic-tracers (wombatlite) as a library
 # - CICE5
 spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [access-esm1p6]
+  - _version: [2026.02.000]
   specs:
-  - access-esm1p6@git.2026.02.000 cice=5
+  - access-esm1p6 cice=5
   packages:
     # Coupler
     oasis3-mct:

--- a/spack.yaml
+++ b/spack.yaml
@@ -62,24 +62,21 @@ spack:
     hdf5:
       require:
       - '@1.14.3'
-    # System dependencies
-    gcc-runtime:
-      require:
-      - '%access_gcc'
-    glibc:
-      require:
-      - '@2.28'
-      - '%access_gcc'
 
     # Compilers
-    intel-oneapi-compilers:
+    c:
       require:
-      - '@2025.2.0'
+      - 'intel-oneapi-compilers@2025.2.0'
+    cxx:
+      require:
+      - 'intel-oneapi-compilers@2025.2.0'
+    fortran:
+      require:
+      - 'intel-oneapi-compilers@2025.2.0'
 
     # Preferences for all packages
     all:
-      require:
-      - '%access_oneapi'
+      prefer:
       - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -65,16 +65,21 @@ spack:
     # System dependencies
     gcc-runtime:
       require:
-      - '%gcc'
+      - '%access_gcc'
     glibc:
       require:
       - '@2.28'
-      - '%gcc'
+      - '%access_gcc'
+
+    # Compilers
+    intel-oneapi-compilers:
+      require:
+      - '@2025.2.0'
 
     # Preferences for all packages
     all:
       require:
-      - '%oneapi@2025.2.0'
+      - '%access_oneapi'
       - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,6 +19,7 @@ spack:
     oasis3-mct:
       require:
       - '@5.2'
+      - 'target=x86_64_v2'
     # Major components
     cice5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-esm1p6]
-  - _version: [2026.02.000]
+  - _version: [2026.02.001]
   specs:
   - access-esm1p6 cice=5
   packages:


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#313 and PR ACCESS-NRI/build-cd#326
References rollout issue ACCESS-NRI/build-cd#328
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!NOTE]
> This infrastructure update created a new Release, but it maintained reproducibility with the current `main`

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for deployments to `spack < 1.0`.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-cd < v8`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-cd >= v8`.

## Background

We are moving on up to `spack v1`! This update to spack contains many bug fixes, optimisations and new features that can be incorporated into `build-cd`.

This update also contains changes that make `spack v0.X` incompatible with this `build-cd v8` update - the most prominent one being the splitting of spacks core codebase from it's builtin spack-packages repo. This means that for provenance, one to keep track of both `builtin` spack-packages and our own, renamed `access-spack-packages`. `build-cd` will centrally control the version of builtin `spack-packages` for a given instance, and `config/versions.json`s `spack-packages` key is renamed to `access-spack-packages`.

As noted earlier, this major version of `build-cd` can only support `spack v1`, due to `spack v1`-specific commands in the infrastructure. If you still want to deploy to `spack v0.X`, you will need to change `build-cd` to `v7`, and update the `config/versions.json` file/`spack.yaml`.

## Features

* **Support for spack v1**: We're moving to a new, non-beta version of spack! It contains bug fixes, features and optimisations over the old version.
* **No more `spack.config`!**: This is now handled in `spack-config` via the `.custom-scopes` key in `config/versions.json`!

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update `config/versions.json` with new inputs (also this PR!)
- [x] Validate compiler additions to the spack manifest (this PR, too!)
- [x] Test and Verify Model built with `spack v1`


---
:rocket: The latest prerelease `access-esm1p6/pr168-6` at 97f59c0c5b1d9dbbf60b01ceedad38061bb1cc8e is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/168#issuecomment-3987369328 :rocket:








---
:rocket: The latest prerelease `access-esm1p6/pr168-7` at 34f23bd5d029f41abf65dabdf15e11bfcaf07f69 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/168#issuecomment-3994997986 :rocket:

