### PR TITLE
Release 2025.11.001: Fix cice5 sndmassnf bug

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,14 +9,14 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.11.001 cice=5
+    - access-esm1p6@git.2025.11.002 cice=5
   packages:
     mom5:
       require:
         - '@git.2025.05.000=access-esm1.6'
     cice5:
       require:
-        - '@git.ea6c1e71a621d0745fedb0321f74cfd32da6b786=access-esm1.6'
+        - '@git.access-esm1.6-2025.11.001=access-esm1.6'
     um7:
       require:
         - '@git.2025.11.000=access-esm1.6'
@@ -76,8 +76,8 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.11.001'
-          cice5: '{name}/access-esm1.6-2025.11.000-{hash:7}'
+          access-esm1p6: '{name}/2025.11.002'
+          cice5: '{name}/access-esm1.6-2025.11.001-{hash:7}'
           um7: '{name}/2025.11.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'
   config:


### PR DESCRIPTION
Updated release with cice5@access-esm1.6-2025.11.001


---
:rocket: The latest prerelease `access-esm1p6/pr169-2` at 485968d573413e723ea034d24faa6a03dc81810d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/169#issuecomment-3568589407 :rocket:



---
:rocket: The latest prerelease `access-esm1p6/pr169-3` at 485968d573413e723ea034d24faa6a03dc81810d is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/169#issuecomment-3568598210 :rocket:
