### PR TITLE
Update UM version

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.11.002 cice=5
+    - access-esm1p6@git.2025.12.000 cice=5
   packages:
     mom5:
       require:
@@ -76,7 +76,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.11.002'
+          access-esm1p6: '{name}/2025.12.000'
           cice5: '{name}/access-esm1.6-2025.11.001-{hash:7}'
           um7: '{name}/2025.12.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'


### PR DESCRIPTION
Closes #175 

This PR updates the UM version to bring in the latest changes for the December spinup

---
:rocket: The latest prerelease `access-esm1p6/pr176-2` at a9a563d46d9991e18aeaa013a479b11b0c05bb14 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/176#issuecomment-3673400356 :rocket:


