### PR TITLE
Update to upstream oasis3-mct v5.2

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.12.000 cice=5
+    - access-esm1p6@git.2025.12.001 cice=5
   packages:
     mom5:
       require:
@@ -29,7 +29,7 @@ spack:
         - '@git.2025.08.000=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.2025.03.001'
+        - '@OASIS3-MCT_5.2'
     openmpi:
       require:
         - '@5.0.8'
@@ -76,7 +76,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p6: '{name}/2025.12.000'
+          access-esm1p6: '{name}/2025.12.001'
           cice5: '{name}/access-esm1.6-2025.11.001-{hash:7}'
           um7: '{name}/2025.12.000-{hash:7}'
           mom5: '{name}/2025.05.000-{hash:7}'


### PR DESCRIPTION
Creating the deployment for merging in the update to oasis3-mct v5.2 - will need to confirm bitwise repro before merging.

---
:rocket: The latest prerelease `access-esm1p6/pr177-17` at 5dfc6e008250822884ae93a9126e3217da725e7f is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/177#issuecomment-3684597866 :rocket:
