### PR TITLE
Change to using ACCESS-NRI organisation OASIS3-mct code

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.11.001"
+    "spack-packages": "4814c0c1ec71cbd4c1bf437c697ee72cd2043332"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "4814c0c1ec71cbd4c1bf437c697ee72cd2043332"
+    "spack-packages": "2026.01.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2026.01.001"
+    "spack-packages": "2026.02.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@
 # - CICE5 from ESM1.6 branch
 spack:
   specs:
-    - access-esm1p6@git.2025.12.001 cice=5
+    - access-esm1p6@git.2026.01.000 cice=5
   packages:
     # Coupler
     oasis3-mct:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,9 +11,11 @@ spack:
   specs:
     - access-esm1p6@git.2025.12.001 cice=5
   packages:
-    mom5:
+    # Coupler
+    oasis3-mct:
       require:
-        - '@git.2025.05.000=access-esm1.6'
+        - '@OASIS3-MCT_5.2'
+    # Major components
     cice5:
       require:
         - '@git.access-esm1.6-2025.11.001=access-esm1.6'
@@ -24,12 +26,25 @@ spack:
       require:
         - '@2025.11.000'
         - library=access-esm1.6
+    mom5:
+      require:
+        - '@git.2025.05.000=access-esm1.6'
+    # Model dependencies
+    # MOM5
+    access-fms:
+      require:
+        - '@git.mom5-2025.08.000=mom5'
+    access-generic-tracers:
+      require:
+        - '@2025.09.000'
+    access-mocsy:
+      require:
+        - '@2025.07.002'
+    # UM7
     gcom4:
       require:
         - '@git.2025.08.000=access-esm1.5'
-    oasis3-mct:
-      require:
-        - '@OASIS3-MCT_5.2'
+    # Shared dependencies
     openmpi:
       require:
         - '@5.0.8'
@@ -42,15 +57,7 @@ spack:
     hdf5:
       require:
         - '@1.14.3'
-    access-fms:
-      require:
-        - '@git.mom5-2025.08.000=mom5'
-    access-generic-tracers:
-      require:
-        - '@2025.09.000'
-    access-mocsy:
-      require:
-        - '@2025.07.002'
+    # System dependencies
     gcc-runtime:
       require:
         - '%gcc'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # Build with:
 # - UM7 from dev-access-esm1.6 branch
 # - MOM5 from master branch with access-generic-tracers (wombatlite) as a library
-# - CICE5 from ESM1.6 branch
+# - CICE5
 spack:
   specs:
     - access-esm1p6@git.2026.01.000 cice=5
@@ -18,7 +18,8 @@ spack:
     # Major components
     cice5:
       require:
-        - '@git.access-esm1.6-2025.11.001=access-esm1.6'
+        - '@2026.01.000'
+        - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
         - '@git.2025.12.000=access-esm1.6'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     # Coupler
     oasis3-mct:
       require:
-        - '@OASIS3-MCT_5.2'
+        - '@5.2'
     # Major components
     cice5:
       require:


### PR DESCRIPTION
This PR will close #179 by specifying a version of OASIS3-mct that uses code from the ACCESS-NRI organisation fork.

Will also close #117 (reorder packages) and hopefully close #180 (use all spack versions) at the same time.

---
:rocket: The latest prerelease `access-esm1p6/pr181-13` at 0693b5e3c148b02d1cb3eb615a538f25f07f15cd is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/181#issuecomment-3844183473 :rocket:












