### PR TITLE
Creating a cice5 with >= 20 cores

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,8 +9,9 @@
 # - CICE5
 spack:
   specs:
-    - access-esm1p6@git.main cice=5 ^cice5 blckx=18 blcky=300
-    - access-esm1p6 cice=5 ^cice5 blckx=30 blcky=150
+    - access-esm1p6@git.main cice=5 ^cice5 blckx=18 blcky=300 # 20x1 slenderX1
+    - access-esm1p6 cice=5 ^cice5 blckx=30 blcky=150 # 12x2 slenderX2
+    - access-esm1p6 cice=5 ^cice5 blckx=15 blcky=300 # 24x1 slenderX1
   packages:
     # Coupler
     oasis3-mct:


### PR DESCRIPTION
Trying a new CICE5 exe with larger number of cores now that I can tune the exact placement with a rankfile.

---
:rocket: The latest prerelease `access-esm1p6/pr188-8` at b89330358556dcca740a57b6f648b51d3b6fd3ab is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/188#issuecomment-3875083507 :rocket:








