### PR TITLE
Test replacing -xCORE-AVX2 with -mavx2

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "dbff638add68e70d48683d06b3bb3ae6ad0a7f38"
+    "spack-packages": "97f928e45d1d7a9f930a5475b8cdb9d3261db472"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "97f928e45d1d7a9f930a5475b8cdb9d3261db472"
+    "spack-packages": "9193e827018c93e64ca16987d7d732ac8961ce92"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2026.02.000"
+    "spack-packages": "dbff638add68e70d48683d06b3bb3ae6ad0a7f38"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
     # Major components
     cice5:
       require:
-        - '@2026.01.000'
+        - '@git.b7b6cff7f60339d8d2fe07cc78d648bb2a9c5b67=2026.01.000'  # On branch 'mavx2'
         - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
@@ -29,18 +29,18 @@ spack:
         - library=access-esm1.6
     mom5:
       require:
-        - '@git.2025.05.000=access-esm1.6'
+        - '@git.fd4e09d8bf26da98cf011624890e136c6e23b705=access-esm1.6'  # On branch 'dkhutch-nesi'
     # Model dependencies
     # MOM5
     access-fms:
       require:
-        - '@git.mom5-2025.08.000=mom5'
+        - '@git.a5259453a6df8d8df1ee934a52e40b6f51735c6b=mom5'  # On branch 'dkhutch-nesi'
     access-generic-tracers:
       require:
-        - '@2025.09.000'
+        - '@git.8fe85c866a8c7a6db41baf7c2412cf50e1e77f95=2025.09.000'  # On branch '2025.09.000-backport-mavx2'
     access-mocsy:
       require:
-        - '@2025.07.002'
+        - '@git.d4475dea14e9f6cf795f59f3f0cd200111ed8d0f=2025.07.002'  # On branch 'dkhutch-nesi'
     # UM7
     gcom4:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
         - library=access-esm1.6
     mom5:
       require:
-        - '@git.fd4e09d8bf26da98cf011624890e136c6e23b705=access-esm1.6'  # On branch 'dkhutch-nesi'
+        - '@git.3a6232e6b42ee1a42558e8262bbaf98e6cec9489=access-esm1.6'  # On branch 'dkhutch-nesi'
     # Model dependencies
     # MOM5
     access-fms:

--- a/spack.yaml
+++ b/spack.yaml
@@ -71,10 +71,13 @@ spack:
     all:
       require:
         - '%oneapi@2025.2.0'
-        - 'target=x86_64_v4'
+        - 'target=sapphirerapids'
   view: true
   concretizer:
     unify: true
+  targets:
+      granularity: microarchitectures
+      host_compatible: false
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,36 +15,66 @@ spack:
     oasis3-mct:
       require:
         - '@5.2'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
     # Major components
     cice5:
       require:
         - '@git.b7b6cff7f60339d8d2fe07cc78d648bb2a9c5b67=2026.01.000'  # On branch 'mavx2'
         - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
     um7:
       require:
         - '@git.2026.02.000=access-esm1.6'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
     cable:
       require:
         - '@2025.11.000'
         - library=access-esm1.6
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
     mom5:
       require:
         - '@git.3a6232e6b42ee1a42558e8262bbaf98e6cec9489=access-esm1.6'  # On branch 'dkhutch-nesi'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
     # Model dependencies
     # MOM5
     access-fms:
       require:
         - '@git.a5259453a6df8d8df1ee934a52e40b6f51735c6b=mom5'  # On branch 'dkhutch-nesi'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
     access-generic-tracers:
       require:
         - '@git.8fe85c866a8c7a6db41baf7c2412cf50e1e77f95=2025.09.000'  # On branch '2025.09.000-backport-mavx2'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
+
     access-mocsy:
       require:
         - '@git.d4475dea14e9f6cf795f59f3f0cd200111ed8d0f=2025.07.002'  # On branch 'dkhutch-nesi'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
+
     # UM7
     gcom4:
       require:
         - '@git.441f3a80332042e276e4437bb01f0ea1b9fa25d5=access-esm1.5'  # On branch 'mavx2'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
+
     # Shared dependencies
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
     # UM7
     gcom4:
       require:
-        - '@git.2025.08.000=access-esm1.5'
+        - '@git.441f3a80332042e276e4437bb01f0ea1b9fa25d5=access-esm1.5'  # On branch 'mavx2'
     # Shared dependencies
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -75,9 +75,9 @@ spack:
   view: true
   concretizer:
     unify: true
-  targets:
-      granularity: microarchitectures
-      host_compatible: false
+    targets:
+        granularity: microarchitectures
+        host_compatible: false
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release

--- a/spack.yaml
+++ b/spack.yaml
@@ -63,9 +63,9 @@ spack:
     access-mocsy:
       require:
         - '@git.d4475dea14e9f6cf795f59f3f0cd200111ed8d0f=2025.07.002'  # On branch 'dkhutch-nesi'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids"'
+        - 'fflags="-O2 -march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cflags="-O2 -march=sapphirerapids -mtune=sapphirerapids"'
+        - 'cxxflags="-O2 -march=sapphirerapids -mtune=sapphirerapids"'
 
     # UM7
     gcom4:


### PR DESCRIPTION
This PR is to test replacing `-xCORE*/-xavx/-axCORE-*` with `-mavx2` across the ACCESS-ESM1.6 stack

---
:rocket: The latest prerelease `access-esm1p6/pr192-11` at d863eb5b3ee61817638c671a78ea50c3e48fc275 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/192#issuecomment-3970463578 :rocket:










