### PR TITLE
Build with optimisation set in SPR, and with the bug-fix from Martin

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "7bc18d819af5cce5e2ae52e21cad7f216a7472f6",
+  "access-spack-packages": "0b247731bdb7180bfaf1f51d3f9aeaf22a4e2b55",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002",
+  "access-spack-packages": "7bc18d819af5cce5e2ae52e21cad7f216a7472f6",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,6 +50,9 @@ spack:
     gcom4:
       require:
       - '@git.2025.08.000=access-esm1.5'
+      - 'fflags="-O2"'
+      - 'cflags="-O2"'
+      - 'cxxflags="-O2"'
     # Shared dependencies
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,40 +19,68 @@ spack:
     oasis3-mct:
       require:
       - '@5.2'
-      - 'target=x86_64_v2'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
     # Major components
     cice5:
       require:
       - '@2026.01.000'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
     um7:
       require:
       - '@git.d309438079d365094eaea25eb0e7041724f8b2da=access-esm1.6'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
     cable:
       require:
       - '@2025.11.000'
       - library=access-esm1.6
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     mom5:
       require:
       - '@git.2025.05.000=access-esm1.6'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     # Model dependencies
     # MOM5
     access-fms:
       require:
       - '@git.mom5-2025.08.000=mom5'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     access-generic-tracers:
       require:
       - '@2025.09.000'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     access-mocsy:
       require:
       - '@2025.07.002'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     # UM7
     gcom4:
       require:
       - '@git.2025.08.000=access-esm1.5'
-      - 'fflags="-O2"'
-      - 'cflags="-O2"'
-      - 'cxxflags="-O2"'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
     # Shared dependencies
     openmpi:
       require:
@@ -60,12 +88,23 @@ spack:
     netcdf-c:
       require:
       - '@4.9.2'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     netcdf-fortran:
       require:
       - '@4.6.1'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
+
     hdf5:
       require:
       - '@1.14.3'
+      - 'fflags="-O2 -xsapphirerapids"'
+      - 'cflags="-O2 -xsapphirerapids"'
+      - 'cxxflags="-O2 -xsapphirerapids"'
 
     # Compilers
     c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.2026.02.000=access-esm1.6'
+      - '@git.03dce1df50d5972867125a5465187621e3448abb=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -88,23 +88,14 @@ spack:
     netcdf-c:
       require:
       - '@4.9.2'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
 
     netcdf-fortran:
       require:
       - '@4.6.1'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
 
     hdf5:
       require:
       - '@1.14.3'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
 
     # Compilers
     c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.03dce1df50d5972867125a5465187621e3448abb=access-esm1.6'
+      - '@git.d309438079d365094eaea25eb0e7041724f8b2da=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,68 +19,68 @@ spack:
     oasis3-mct:
       require:
       - '@5.2'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
     # Major components
     cice5:
       require:
       - '@2026.01.000'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
     um7:
       require:
       - '@git.d309438079d365094eaea25eb0e7041724f8b2da=access-esm1.6'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
     cable:
       require:
       - '@2025.11.000'
       - library=access-esm1.6
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
 
     mom5:
       require:
       - '@git.2025.05.000=access-esm1.6'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
 
     # Model dependencies
     # MOM5
     access-fms:
       require:
       - '@git.mom5-2025.08.000=mom5'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
 
     access-generic-tracers:
       require:
       - '@2025.09.000'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
 
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
 
     # UM7
     gcom4:
       require:
       - '@git.2025.08.000=access-esm1.5'
-      - 'fflags="-O2 -xsapphirerapids"'
-      - 'cflags="-O2 -xsapphirerapids"'
-      - 'cxxflags="-O2 -xsapphirerapids"'
+      - 'fflags="-O2 -xcascadelake"'
+      - 'cflags="-O2 -xcascadelake"'
+      - 'cxxflags="-O2 -xcascadelake"'
     # Shared dependencies
     openmpi:
       require:


### PR DESCRIPTION
Using an updated UM7 SPR that sets -O2 for atm_step and u_model, and keeps -O0 for set_atm_pointers + building UM7 with the bug-fix from Martin (that fixes the wrong offsets which were unveiled by my setting the -O2 flags across all three top-level UM7 routines)


---
:rocket: The latest prerelease `access-esm1p6/pr193-10` at 82e41f9bcd8dc1896c2ac6d61d96974a84ccd3c3 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/193#issuecomment-4067419742 :rocket:










