### PR TITLE
Update to UM version with CO2 flux conservation fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-esm1p6]
-  - _version: [2026.02.001]
+  - _version: [2026.04.000]
   specs:
   - access-esm1p6 cice=5
   packages:
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.2026.02.000=access-esm1.6'
+      - '@git.2026.04.000=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'


### PR DESCRIPTION
Closes #196. This PR updates the UM version to include the CO2 conservation fix from https://github.com/ACCESS-NRI/UM7/pull/209. This change is required for the next set of emissions driven simulations for CMIP6.

---
:rocket: The latest prerelease `access-esm1p6/pr197-15` at 6452c5e7793815a6e3110866136f59250049e41c is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/197#issuecomment-4240440817 :rocket:















