### PR TITLE
CO2 build test 3

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-esm1p6]
-  - _version: [2026.02.001]
+  - _version: [2026.04.000]
   specs:
   - access-esm1p6 cice=5
   packages:
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.2026.02.000=access-esm1.6'
+      - '@git.2026.04.000=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.2026.04.000=access-esm1.6'
+      - '@git.0641260314639690955ee9144da11e9c632eb832=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'


### PR DESCRIPTION
Added whitespace to the UM code, checking if get the same error.

---
:rocket: The latest prerelease `access-esm1p6/pr199-3` at 119ab592ef4643e5391a04b3261a370d2756a865 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/199#issuecomment-4233052726 :rocket:


