### PR TITLE
Change whitespace UM code

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.2026.02.000=access-esm1.6'
+      - '@git.ff5063d7efc33cb054c39391e55f1aec1ac15c89=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-esm1p6]
-  - _version: [2026.02.001]
+  - _version: [2026.04.000]
   specs:
   - access-esm1p6 cice=5
   packages:
@@ -27,7 +27,7 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.ff5063d7efc33cb054c39391e55f1aec1ac15c89=access-esm1.6'
+      - '@git.2026.04.000=access-esm1.6'
     cable:
       require:
       - '@2025.11.000'


### PR DESCRIPTION
Use the same code as the [last successful deployment](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/releases/tag/2026.02.001), but add a whitespace change to the UM

---
:rocket: The latest prerelease `access-esm1p6/pr200-2` at 39c7d982114b36f808bc6a837cdd1bb369811cf9 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/200#issuecomment-4234649073 :rocket:

