### PR TITLE
Test cice output times

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
     # Major components
     cice5:
       require:
-      - '@git.6ccb7b0181555c759315728835f5325275c2f04c'
+      - '@git.3b0d47da374520da6b33acaa06466e7933df5b07'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
     # Major components
     cice5:
       require:
-      - '@git.3b0d47da374520da6b33acaa06466e7933df5b07'
+      - '@git.84cc7eed0bf4b448a05a4e05c34bc7b1fe670848'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
     # Major components
     cice5:
       require:
-      - '@git.84cc7eed0bf4b448a05a4e05c34bc7b1fe670848'
+      - '@git.0c56a28bef42ed76a810f3049f042588b2889aa8'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
     # Major components
     cice5:
       require:
-      - '@git.4b24c144beab4c6c634a5d3f7161ed1f5ef54d71'
+      - '@git.6ccb7b0181555c759315728835f5325275c2f04c'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
     # Major components
     cice5:
       require:
-      - '@2026.01.000'
+      - '@git.4b24c144beab4c6c634a5d3f7161ed1f5ef54d71'
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:


### PR DESCRIPTION
Draft PR for testing changes to CICE output times. Not to be merged.

---
:rocket: The latest prerelease `access-esm1p6/pr202-9` at a467848674a01631555405dc2672fe38adb72e7c is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/202#issuecomment-4788714481 :rocket:








