### PR TITLE
spack.yaml: use real versions

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002",
+  "access-spack-packages": "2026.08.000",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,19 +27,19 @@ spack:
       - 'nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1' # grid size and block size
     um7:
       require:
-      - '@git.2026.04.000=access-esm1.6'
+      - '@2026.04.000'
     cable:
       require:
       - '@2025.11.000'
       - library=access-esm1.6
     mom5:
       require:
-      - '@git.2025.05.000=access-esm1.6'
+      - '@2025.05.000'
     # Model dependencies
     # MOM5
     access-fms:
       require:
-      - '@git.mom5-2025.08.000=mom5'
+      - '@2025.08.000'
     access-generic-tracers:
       require:
       - '@2025.09.000'
@@ -49,7 +49,7 @@ spack:
     # UM7
     gcom4:
       require:
-      - '@git.2025.08.000=access-esm1.5'
+      - '@2025.08.000'
     # Shared dependencies
     openmpi:
       require:


### PR DESCRIPTION
Closes: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/issues/180
* This PR uses https://github.com/ACCESS-NRI/access-spack-packages/tree/cleanup-before-esm1.6-release
* Use a tag in config/versions.json before merging.

---
:rocket: The latest prerelease `access-esm1p6/pr212-2` at c7b02b0db7133ebbcc979e6913e195f552d6ef20 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/212#issuecomment-5132220487 :rocket:


---
:rocket: The latest prerelease `access-esm1p6/pr212-12` at d874e8c60242c095fe092fd3c5f8df7b05b4ab85 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/212#issuecomment-5199023726 :rocket:










