### PR TITLE
Test access-spack-packages branch `cleanup-before-esm1.6-release`

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002",
+  "access-spack-packages": "e8ed648739ad761f3fef29dd7535d4168beb3f0d",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -34,12 +34,12 @@ spack:
       - library=access-esm1.6
     mom5:
       require:
-      - '@git.2025.05.000=access-esm1.6'
+      - '@2025.05.000'
     # Model dependencies
     # MOM5
     access-fms:
       require:
-      - '@git.mom5-2025.08.000=mom5'
+      - '@2025.08.000'
     access-generic-tracers:
       require:
       - '@2025.09.000'


### PR DESCRIPTION
This PR is to test the proposed changes to `access-spack-packages` in [this PR](https://github.com/ACCESS-NRI/access-spack-packages/pull/443), which:

- removes support for ACCESS-ESM1.5
- removes makefile support from the mom5 SPR
- moves mom5, access_fms, libaccessom2 to numerical versioning

---
:rocket: The latest prerelease `access-esm1p6/pr214-1` at bf8a41f524b569f5cd182147f2cbf717b7036697 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/214#issuecomment-5126580290 :rocket:
