### PR TITLE
Next release (2026.??.???)

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -40,12 +40,12 @@ spack:
       - library=access-esm1.6
     mom5:
       require:
-      - '@2025.05.000'
+      - '@2026.02.001'
     # Model dependencies
     # MOM5
     access-fms:
       require:
-      - '@2025.08.000'
+      - '@2025.08.001'
     access-generic-tracers:
       require:
       - '@2025.09.000'
@@ -91,5 +91,5 @@ spack:
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      tag: 2026.08.004
+      tag: 2026.08.007
       destination: $env/package-repos/access-spack-packages


### PR DESCRIPTION
Changes for the next release of ACCESS-ESM1.6. I haven't set the version yet because I'm not 100% on what will be included.

Currently includes:
- [x] Update to MOM5 2026.02.001
  - Includes corrections to some diagnostics' units, and fixes for compiling with GCC
  - This was intended to be done in the [previous release](https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/213) but was accidentally removed
- [x] Update to FMS 2025.08.001
  - Added control of date stamp formatting in diagnostic filenames

- [ ] gfortran related fixes for UM
---
:rocket: The latest prerelease `access-esm1p6/pr218-1` at e6eae45cdcbbb40a402df4031b49da9cad191e4b is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/218#issuecomment-5288746580 :rocket:
